### PR TITLE
Integrate IAP view directly into inbox tab

### DIFF
--- a/ArchiverLib/Package.resolved
+++ b/ArchiverLib/Package.resolved
@@ -1,0 +1,150 @@
+{
+  "originHash" : "e579cd6cff21618242b29029522a707c1ddd42bf0eed5a9b2bfc63ddb09e11c8",
+  "pins" : [
+    {
+      "identity" : "asyncextensions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sideeffect-io/AsyncExtensions",
+      "state" : {
+        "revision" : "735748a3ffb7ec880aa252e1c38ec0a65929cb87",
+        "version" : "0.5.4"
+      }
+    },
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms",
+      "state" : {
+        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
+        "version" : "1.7.2"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "revision" : "2d60d4082dfb4978974307acf0f00dfa20e5f621",
+        "version" : "1.22.3"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "a10f9feeb214bc72b5337b6ef6d5a029360db4cc",
+        "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "91415670c91d41e8e1872ef6fe1bf118e20dee37",
+        "version" : "2.5.1"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "30721accd0370d7c9cb5bd0f7cdf5a1a767b383d",
+        "version" : "2.0.8"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
+        "version" : "2.7.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
+        "version" : "1.7.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ArchiverLib/Sources/ArchiverFeatures/Other/PremiumSectionView.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/Other/PremiumSectionView.swift
@@ -23,7 +23,7 @@ struct PremiumSection {
         case delegate(Delegate)
 
         enum Delegate: Equatable {
-          case onShowIapButtonTapped
+          case switchToInboxTab
         }
     }
 
@@ -60,7 +60,7 @@ struct PremiumSection {
             }
             if store.premiumStatus == .inactive {
                 Button {
-                    store.send(.delegate(.onShowIapButtonTapped))
+                    store.send(.delegate(.switchToInboxTab))
                 } label: {
                     Text("Activate premium", bundle: .module)
                 }

--- a/ArchiverLib/Sources/ArchiverFeatures/Settings/Settings.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/Settings/Settings.swift
@@ -153,6 +153,10 @@ struct Settings {
                 state.destination = .termsOfUse
                 return .none
 
+            case .premiumSection(.delegate):
+                // Forward delegate actions to parent
+                return .none
+
             case .premiumSection:
                 return .none
             }


### PR DESCRIPTION
## Summary
- Moves In-App Purchase view from modal sheet to inline display in inbox tab
- Removes `showIapView` state and sheet presentation from `AppFeature`
- Premium activation button in settings now navigates to inbox tab instead of showing sheet
- Adds delegate pattern to `UntaggedDocumentList` for tab navigation coordination

## Benefits
- More intuitive user flow - users can see the IAP view directly when accessing inbox
- Reduced state complexity by removing global sheet state management
- Better visual context for premium features within the inbox
- Cleaner architecture with delegate-based communication

## Test plan
- [ ] Verify IAP view displays correctly in inbox tab when premium is inactive
- [ ] Test premium activation button in settings navigates to inbox
- [ ] Confirm cancel button in IAP view returns to search tab
- [ ] Check that inbox shows documents list when premium is active
- [ ] Test empty state message when all documents are tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)