### PR TITLE
Simplify subscription management by using openURL on all platforms

### DIFF
--- a/ArchiverLib/Sources/ArchiverFeatures/Other/PremiumSectionView.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/Other/PremiumSectionView.swift
@@ -16,7 +16,6 @@ struct PremiumSection {
     struct State: Equatable {
         @Shared(.premiumStatus) var premiumStatus: PremiumStatus = .loading
         var showIapView = false
-        var showManageSubscription = false
     }
 
     enum Action: BindableAction, Equatable {
@@ -36,15 +35,10 @@ struct PremiumSection {
         Reduce { state, action in
             switch action {
             case .showManageSubscription:
-                #if os(iOS)
-                state.showManageSubscription = true
-                return .none
-                #else
                 return .run { _ in
                     let url = URL(string: "https://apps.apple.com/account/subscriptions")!
                     await openURL(url)
                 }
-                #endif
 
             case .binding, .delegate:
                 return .none
@@ -144,9 +138,6 @@ struct PremiumSection {
             Text("Premium", bundle: .module)
                 .foregroundStyle(Color.secondary)
         }
-        #if !os(macOS)
-        .manageSubscriptionsSheet(isPresented: $store.showManageSubscription)
-        #endif
     }
  }
 


### PR DESCRIPTION
## Summary

- Removed platform-specific subscription management sheet handling
- Unified subscription management to use `openURL` on both iOS and macOS
- Removed `showManageSubscription` state variable from `PremiumSection.State`
- Removed iOS-specific `.manageSubscriptionsSheet` modifier
- Cleaned up conditional compilation directives

## Changes

**Before:** iOS used a native subscription management sheet via `.manageSubscriptionsSheet`, while macOS used `openURL`.

**After:** Both platforms now consistently use `openURL` to open the Apple subscription management page (`https://apps.apple.com/account/subscriptions`) in the system browser.

## Benefits

- Simpler, more maintainable code
- Consistent behavior across platforms
- Reduced state management complexity
- Fewer platform-specific conditionals

## Test plan

- [ ] Build and run on iOS - verify "Manage Subscription" button opens subscription management in Safari
- [ ] Build and run on macOS - verify "Manage Subscription" button opens subscription management in browser
- [ ] Verify no compilation errors in ArchiverLib package
- [ ] Test with both active and inactive premium status

🤖 Generated with [Claude Code](https://claude.com/claude-code)