### PR TITLE
Remove background view from Share Extension

### DIFF
--- a/ShareExtension/MainInterface.storyboard
+++ b/ShareExtension/MainInterface.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24128" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -17,60 +17,46 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a8N-9k-TSh">
-                                <rect key="frame" x="100" y="348" width="214" height="214"/>
-                                <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Xen-Kg-1RO">
-                                        <rect key="frame" x="88.5" y="112" width="37" height="36"/>
-                                        <color key="tintColor" systemColor="labelColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="Xen-Kg-1RO" secondAttribute="height" multiplier="1:1" id="Bod-Qi-KPw"/>
-                                        </constraints>
-                                    </imageView>
-                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="mH6-As-MhU">
-                                        <rect key="frame" x="88.5" y="111.5" width="37" height="37"/>
-                                    </activityIndicatorView>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="document" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ucA-hY-Jll" customClass="AppIcon">
-                                        <rect key="frame" x="20" y="20" width="44" height="44"/>
-                                        <color key="tintColor" name="DarkRed"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="ucA-hY-Jll" secondAttribute="height" multiplier="1:1" id="e1g-Xd-8hs"/>
-                                            <constraint firstAttribute="height" constant="44" id="gLP-1r-Agx"/>
-                                        </constraints>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Import" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eV9-11-d6Z">
-                                        <rect key="frame" x="80" y="29" width="118" height="26.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Xen-Kg-1RO">
+                                <rect key="frame" x="188.5" y="433.5" width="37" height="36"/>
+                                <color key="tintColor" systemColor="labelColor"/>
                                 <constraints>
-                                    <constraint firstItem="mH6-As-MhU" firstAttribute="top" secondItem="eV9-11-d6Z" secondAttribute="bottom" constant="56" id="5lH-Ov-2nL"/>
-                                    <constraint firstAttribute="trailing" secondItem="eV9-11-d6Z" secondAttribute="trailing" constant="16" id="Ctu-kw-8kN"/>
-                                    <constraint firstItem="eV9-11-d6Z" firstAttribute="centerY" secondItem="ucA-hY-Jll" secondAttribute="centerY" id="DGf-St-VQ3"/>
-                                    <constraint firstItem="mH6-As-MhU" firstAttribute="centerY" secondItem="Xen-Kg-1RO" secondAttribute="centerY" id="feN-hd-ZuA"/>
-                                    <constraint firstItem="ucA-hY-Jll" firstAttribute="top" secondItem="a8N-9k-TSh" secondAttribute="top" constant="20" id="gf2-5D-jbF"/>
-                                    <constraint firstItem="eV9-11-d6Z" firstAttribute="leading" secondItem="ucA-hY-Jll" secondAttribute="trailing" constant="16" id="gz7-cs-9J5"/>
-                                    <constraint firstItem="Xen-Kg-1RO" firstAttribute="top" secondItem="eV9-11-d6Z" secondAttribute="bottom" constant="56" id="j8o-bO-1Nv"/>
-                                    <constraint firstItem="mH6-As-MhU" firstAttribute="centerX" secondItem="a8N-9k-TSh" secondAttribute="centerX" id="tCD-1D-v0d"/>
-                                    <constraint firstItem="ucA-hY-Jll" firstAttribute="leading" secondItem="a8N-9k-TSh" secondAttribute="leading" constant="20" id="vbk-La-TxB"/>
-                                    <constraint firstItem="Xen-Kg-1RO" firstAttribute="centerX" secondItem="a8N-9k-TSh" secondAttribute="centerX" id="vdK-cy-BCk"/>
-                                    <constraint firstAttribute="width" secondItem="a8N-9k-TSh" secondAttribute="height" multiplier="1:1" id="yj6-2n-wdX"/>
+                                    <constraint firstAttribute="width" secondItem="Xen-Kg-1RO" secondAttribute="height" multiplier="1:1" id="Bod-Qi-KPw"/>
                                 </constraints>
-                            </view>
+                            </imageView>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="mH6-As-MhU">
+                                <rect key="frame" x="188.5" y="433" width="37" height="37"/>
+                            </activityIndicatorView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="document" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ucA-hY-Jll" customClass="AppIcon">
+                                <rect key="frame" x="120" y="346" width="60" height="60"/>
+                                <color key="tintColor" name="DarkRed"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="ucA-hY-Jll" secondAttribute="height" multiplier="1:1" id="e1g-Xd-8hs"/>
+                                    <constraint firstAttribute="height" constant="60" id="gLP-1r-Agx"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Import" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eV9-11-d6Z">
+                                <rect key="frame" x="196" y="363" width="62.5" height="26.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="1Xd-am-t49"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="a8N-9k-TSh" firstAttribute="centerY" secondItem="1Xd-am-t49" secondAttribute="centerY" id="8ks-fs-zon"/>
-                            <constraint firstItem="a8N-9k-TSh" firstAttribute="leading" secondItem="1Xd-am-t49" secondAttribute="leading" constant="100" id="9Gr-tu-fzT"/>
-                            <constraint firstItem="a8N-9k-TSh" firstAttribute="centerX" secondItem="1Xd-am-t49" secondAttribute="centerX" id="ot1-hL-Ffd"/>
+                            <constraint firstItem="mH6-As-MhU" firstAttribute="top" secondItem="eV9-11-d6Z" secondAttribute="bottom" constant="43.5" id="5lH-Ov-2nL"/>
+                            <constraint firstItem="eV9-11-d6Z" firstAttribute="centerY" secondItem="ucA-hY-Jll" secondAttribute="centerY" id="DGf-St-VQ3"/>
+                            <constraint firstItem="mH6-As-MhU" firstAttribute="centerY" secondItem="Xen-Kg-1RO" secondAttribute="centerY" id="feN-hd-ZuA"/>
+                            <constraint firstItem="eV9-11-d6Z" firstAttribute="leading" secondItem="ucA-hY-Jll" secondAttribute="trailing" constant="16" id="gz7-cs-9J5"/>
+                            <constraint firstItem="Xen-Kg-1RO" firstAttribute="top" secondItem="eV9-11-d6Z" secondAttribute="bottom" constant="43.5" id="j8o-bO-1Nv"/>
+                            <constraint firstItem="mH6-As-MhU" firstAttribute="centerX" secondItem="wbc-yd-nQP" secondAttribute="centerX" id="tCD-1D-v0d"/>
+                            <constraint firstItem="ucA-hY-Jll" firstAttribute="leading" secondItem="1Xd-am-t49" secondAttribute="leading" constant="120" id="vbk-La-TxB"/>
+                            <constraint firstItem="Xen-Kg-1RO" firstAttribute="centerX" secondItem="wbc-yd-nQP" secondAttribute="centerX" id="vdK-cy-BCk"/>
+                            <constraint firstItem="ucA-hY-Jll" firstAttribute="centerY" secondItem="wbc-yd-nQP" secondAttribute="centerY" constant="-72" id="xYz-Aa-123"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="activityIndicator" destination="mH6-As-MhU" id="UJp-Tn-0fV"/>
-                        <outlet property="backgroundView" destination="a8N-9k-TSh" id="csB-m8-ce9"/>
                         <outlet property="checkmark" destination="Xen-Kg-1RO" id="sJQ-Ea-U5D"/>
                     </connections>
                 </viewController>
@@ -87,9 +73,6 @@
         </namedColor>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -28,7 +28,6 @@ final class ShareViewController: UIViewController {
         .image
     ]
 
-    @IBOutlet private weak var backgroundView: UIView!
     @IBOutlet private weak var activityIndicator: UIActivityIndicatorView!
     @IBOutlet private weak var checkmark: UIImageView!
 
@@ -37,7 +36,6 @@ final class ShareViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        backgroundView.layer.cornerRadius = 25
         activityIndicator.startAnimating()
         activityIndicator.hidesWhenStopped = true
         checkmark.isHidden = true


### PR DESCRIPTION
## Changes
- Removed `backgroundView` outlet from ShareViewController
- Removed background view container from MainInterface.storyboard
- Restructured UI elements to sit directly in transparent main view
- Updated constraints for centered positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)