### PR TITLE
refactor: replace replacingOccurrences with replacing method

### DIFF
--- a/ArchiverLib/Sources/ArchiverStore/Extensions/Document.swift
+++ b/ArchiverLib/Sources/ArchiverStore/Extensions/Document.swift
@@ -24,7 +24,7 @@ extension Document {
         let tags = Set(data.tagNames ?? [])
 
         let date = data.date ?? url.fileCreationDate() ?? Date()
-        let specification = isTagged ? data.specification?.replacingOccurrences(of: "-", with: " ") : data.specification
+        let specification = isTagged ? data.specification?.replacing("-", with: " ") : data.specification
 
         return Document(id: id,
                         url: url,

--- a/ArchiverLib/Sources/Shared/Extensions/String.swift
+++ b/ArchiverLib/Sources/Shared/Extensions/String.swift
@@ -16,17 +16,17 @@ nonisolated public extension String {
         // this function is inspired by:
         // https://github.com/malt03/SwiftString/blob/0aeb47cbfa77cf8552bbadf49360ef529fbb8c03/Sources/StringExtensions.swift#L194
         let slugCharacterSet = NSCharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\(separator)")
-        return replacingOccurrences(of: "ß", with: "ss")
-            .replacingOccurrences(of: "Ä", with: "Ae")
-            .replacingOccurrences(of: "Ö", with: "Oe")
-            .replacingOccurrences(of: "Ü", with: "Ue")
-            .replacingOccurrences(of: "ä", with: "ae")
-            .replacingOccurrences(of: "ö", with: "oe")
-            .replacingOccurrences(of: "ü", with: "ue")
+        return replacing("ß", with: "ss")
+            .replacing("Ä", with: "Ae")
+            .replacing("Ö", with: "Oe")
+            .replacing("Ü", with: "Ue")
+            .replacing("ä", with: "ae")
+            .replacing("ö", with: "oe")
+            .replacing("ü", with: "ue")
             .folding(options: .diacriticInsensitive, locale: .current)
             .components(separatedBy: slugCharacterSet.inverted)
             .filter { !$0.isEmpty }
             .joined(separator: separator)
-            .replacingOccurrences(of: "[^0-9a-zA-Z]+", with: separator, options: .regularExpression, range: nil)
+            .replacing(/[^0-9a-zA-Z]+/, with: separator)
     }
 }

--- a/ArchiverLib/Sources/Shared/Other/DateParser.swift
+++ b/ArchiverLib/Sources/Shared/Other/DateParser.swift
@@ -35,7 +35,7 @@ nonisolated public enum DateParser: Log {
                 .map(\.0)
         } else if let date = DateFormatter.yyyyMMdd.date(from: input) {
             return [date]
-        } else if let date = DateFormatter.yyyyMMdd.date(from: input.replacingOccurrences(of: "_", with: "-")) {
+        } else if let date = DateFormatter.yyyyMMdd.date(from: input.replacing("_", with: "-")) {
             return [date]
         } else {
             return []

--- a/ArchiverLib/Sources/Shared/Views/MarkdownView.swift
+++ b/ArchiverLib/Sources/Shared/Views/MarkdownView.swift
@@ -157,8 +157,8 @@ private enum MarkdownParser {
 
     static func parse(_ text: String) -> [Block] {
         var blocks: [Block] = []
-        let lines = text.replacingOccurrences(of: "\r\n", with: "\n")
-                        .replacingOccurrences(of: "\r", with: "\n")
+        let lines = text.replacing("\r\n", with: "\n")
+                        .replacing("\r", with: "\n")
                         .split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
                         .map(String.init)
 

--- a/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/DateParserTests.swift
+++ b/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/DateParserTests.swift
@@ -181,4 +181,22 @@ struct DateParserTests {
             Issue.record("No date was found, this should not happen in this test.")
         }
     }
+
+    @Test
+    func testParsingDateWithUnderscores() async throws {
+
+        // setup - test replacing underscores with dashes
+        let input = "1990_02_11"
+
+        // calculate
+        let parsedOutput = await DateParser.parse(input)
+
+        // assert
+        if let parsedDate = parsedOutput.first {
+            let expectedDate = try #require(dateFormatter.date(from: "1990-02-11"))
+            #expect(Calendar.current.isDate(parsedDate, inSameDayAs: expectedDate))
+        } else {
+            Issue.record("No date was found for underscore-separated date format.")
+        }
+    }
 }

--- a/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/StringTests.swift
+++ b/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/StringTests.swift
@@ -66,4 +66,50 @@ struct StringExtensionTests {
         // assert
         #expect(output == "This Is Another Test")
     }
+
+    @Test
+    func testReplacingMethod() {
+
+        // setup
+        let testString = "Äpfel und Öl"
+
+        // calculate
+        let output = testString.replacing("Ä", with: "Ae")
+                                .replacing("Ö", with: "Oe")
+
+        // assert
+        #expect(output == "Aepfel und Oel")
+    }
+
+    @Test
+    func testReplacingWithRegex() {
+
+        // setup
+        let testString = "test--multiple---dashes"
+
+        // calculate
+        let output = testString.replacing(/[^0-9a-zA-Z]+/, with: "-")
+
+        // assert
+        #expect(output == "test-multiple-dashes")
+    }
+
+    @Test
+    func testReplacingSpecialCharacters() {
+
+        // setup
+        let testString = "ß test ä ö ü Ä Ö Ü"
+
+        // calculate
+        let output = testString.replacing("ß", with: "ss")
+                                .replacing("ä", with: "ae")
+                                .replacing("ö", with: "oe")
+                                .replacing("ü", with: "ue")
+                                .replacing("Ä", with: "Ae")
+                                .replacing("Ö", with: "Oe")
+                                .replacing("Ü", with: "Ue")
+
+        // assert
+        #expect(output == "ss test ae oe ue Ae Oe Ue")
+    }
 }


### PR DESCRIPTION
## Changes
- Replaced `replacingOccurrences(of:with:)` with modern `replacing(_:with:)` method
- Converted regex replacement to use Regex literal syntax
- Added unit tests for string replacement functionality
- Added test for underscore-to-dash date parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)