### PR TITLE
Fix small widget number truncation

### DIFF
--- a/ArchiverLib/Sources/ArchiverFeatures/DocumentInformationForm/DocumentInformationForm.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/DocumentInformationForm/DocumentInformationForm.swift
@@ -177,7 +177,7 @@ struct DocumentInformationForm {
                     state.isTagSelectionDelayActive = true
                     state.tagSelectionDelayProgress = 0.0
 
-                    return .run { [clock] send in
+                    return .run { send in
                         let delayDuration: TimeInterval = 2
                         let steps = 20
                         let stepDuration = delayDuration / Double(steps)

--- a/ArchiverLib/Sources/ArchiverIntents/Views/UntaggedDocumentsStatsView.swift
+++ b/ArchiverLib/Sources/ArchiverIntents/Views/UntaggedDocumentsStatsView.swift
@@ -67,6 +67,8 @@ public struct UntaggedDocumentsStatsView: View {
                             Text(untaggedDocuments, format: .number)
                                 .fontWeight(.black)
                                 .foregroundStyle(.primary)
+                                .minimumScaleFactor(0.5)
+                                .lineLimit(1)
 
                             Image(systemName: "document.on.document")
                                 .foregroundStyle(Color.paRedAsset)
@@ -166,12 +168,24 @@ public struct UntaggedDocumentsStatsView: View {
 
 #Preview("Small") {
     List {
-        Section {
+        Section("Zero documents") {
             UntaggedDocumentsStatsView(untaggedDocuments: 0,
                                        size: .small)
         }
-        Section {
-            UntaggedDocumentsStatsView(untaggedDocuments: 0,
+        Section("Single digit") {
+            UntaggedDocumentsStatsView(untaggedDocuments: 5,
+                                       size: .small)
+        }
+        Section("Double digits") {
+            UntaggedDocumentsStatsView(untaggedDocuments: 42,
+                                       size: .small)
+        }
+        Section("Triple digits") {
+            UntaggedDocumentsStatsView(untaggedDocuments: 542,
+                                       size: .small)
+        }
+        Section("Edge case - 999") {
+            UntaggedDocumentsStatsView(untaggedDocuments: 999,
                                        size: .small)
         }
     }


### PR DESCRIPTION
## Changes
- Added `.minimumScaleFactor(0.5)` to number Text view in small widget
- Added `.lineLimit(1)` to prevent multi-line wrapping
- Enhanced preview cases to test single, double, and triple-digit numbers

Fixes #251