### PR TITLE
feat: DocumentProcessingPipeline with OCR and AI cache

### DIFF
--- a/ArchiverLib.xctestplan
+++ b/ArchiverLib.xctestplan
@@ -33,6 +33,13 @@
         "identifier" : "ArchiverDocumentProcessingTests",
         "name" : "ArchiverDocumentProcessingTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "DocumentProcessingPipelineTests",
+        "name" : "DocumentProcessingPipelineTests"
+      }
     }
   ],
   "version" : 1

--- a/ArchiverLib/Package.swift
+++ b/ArchiverLib/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
                     "ArchiverIntents",
                     "ArchiverStore",
                     "ContentExtractorStore",
+                    "DocumentProcessingPipeline",
                     "Shared",
                     .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
                 ],
@@ -66,6 +67,16 @@ let package = Package(
                     .product(name: "Dependencies", package: "swift-dependencies"),
                     .product(name: "DependenciesMacros", package: "swift-dependencies")
                 ]),
+        .target(name: "DocumentProcessingPipeline",
+                dependencies: [
+                    "ArchiverModels",
+                    "ArchiverStore",
+                    "ContentExtractorStore",
+                    "Shared",
+                    .product(name: "Dependencies", package: "swift-dependencies"),
+                    .product(name: "DependenciesMacros", package: "swift-dependencies"),
+                    .product(name: "Sharing", package: "swift-sharing")
+                ]),
         .target(name: "Shared",
                 dependencies: [
                     "ArchiverModels",
@@ -75,9 +86,17 @@ let package = Package(
                     .process("Resources/Localizable.xcstrings"),
                     .process("Resources/Assets.xcassets")
                 ]),
+        .executableTarget(
+            name: "ocr-tool",
+            dependencies: ["DocumentProcessingPipeline"]
+        ),
         .testTarget(
             name: "ArchiverFeaturesTests",
             dependencies: ["ArchiverFeatures"]
+        ),
+        .testTarget(
+            name: "DocumentProcessingPipelineTests",
+            dependencies: ["DocumentProcessingPipeline", "ContentExtractorStore"]
         ),
         .testTarget(
             name: "ArchiverStoreTests",

--- a/ArchiverLib/Sources/ArchiverFeatures/AppFeature/AppFeature.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/AppFeature/AppFeature.swift
@@ -7,6 +7,7 @@
 
 import ArchiverModels
 import ComposableArchitecture
+import DocumentProcessingPipeline
 import OSLog
 import Shared
 import SwiftUI
@@ -30,14 +31,9 @@ struct AppFeature {
         @Shared(.tutorialShown) var tutorialShown: Bool
         @Shared(.premiumStatus) var premiumStatus: PremiumStatus = .loading
 
-        @SharedReader(.appleIntelligenceEnabled)
-        var appleIntelligenceEnabled: Bool
-
-        @SharedReader(.appleIntelligenceCacheEnabled)
-        var cacheEnabled: Bool
-
-        @SharedReader(.appleIntelligenceCustomPrompt)
-        var customPrompt: String?
+        @SharedReader(.ocrEnabled) var ocrEnabled: Bool
+        @SharedReader(.appleIntelligenceEnabled) var aiEnabled: Bool
+        @SharedReader(.appleIntelligenceCacheEnabled) var aiCacheEnabled: Bool
 
         var scenePhase: ScenePhase?
 
@@ -74,7 +70,7 @@ struct AppFeature {
     @Dependency(\.documentProcessor) var documentProcessor
     @Dependency(\.archiveStore) var archiveStore
     @Dependency(\.widgetStore) var widgetStore
-    @Dependency(\.contentExtractorStore) var contentExtractorStore
+    @Dependency(\.documentProcessingPipeline) var documentProcessingPipeline
     @Dependency(\.textAnalyser) var textAnalyser
 
     var body: some ReducerOf<Self> {
@@ -219,7 +215,11 @@ struct AppFeature {
                 return .none
 
             case .onLongBackgroundTask:
-                return .run { [appleIntelligenceEnabled = state.appleIntelligenceEnabled, cacheEnabled = state.cacheEnabled, customPrompt = state.customPrompt] send in
+                return .run { [
+                    ocrEnabled = state.ocrEnabled,
+                    aiEnabled = state.aiEnabled,
+                    aiCacheEnabled = state.aiCacheEnabled
+                ] send in
                     await withTaskGroup(of: Void.self) { group in
                         group.addTask(priority: .background) {
                             // check the temp folder at startup for new documents
@@ -243,22 +243,26 @@ struct AppFeature {
                                 await send(.isLoadingChanged(isLoading))
                             }
                         }
-                        // Background cache processing for untagged documents
-                        if appleIntelligenceEnabled && cacheEnabled {
-                            group.addTask(priority: .background) {
-                                // Wait a bit before starting cache processing to let the app stabilize
-                                try? await Task.sleep(for: .seconds(10))
+                        // Background processing pipeline (OCR + AI Cache)
+                        group.addTask(priority: .background) {
+                            // Wait a bit before starting processing to let the app stabilize
+                            try? await Task.sleep(for: .seconds(5))
 
-                                do {
-                                    let documents = try await archiveStore.getDocuments()
-                                    _ = await contentExtractorStore.processUntaggedDocumentsInBackground(
-                                        documents,
-                                        textAnalyser.getTextFrom,
-                                        customPrompt
-                                    )
-                                } catch {
-                                    Logger.app.error("Failed to load documents for background cache processing: \(error)")
-                                }
+                            do {
+                                var steps: Set<PipelineConfiguration.StepKind> = []
+                                if ocrEnabled { steps.insert(.ocr) }
+                                if aiEnabled && aiCacheEnabled { steps.insert(.aiCache) }
+                                guard !steps.isEmpty else { return }
+
+                                let documents = try await archiveStore.getDocuments()
+                                let untaggedURLs = documents.filter { !$0.isTagged }.map(\.url)
+                                let config = PipelineConfiguration(
+                                    urls: untaggedURLs,
+                                    steps: steps
+                                )
+                                _ = await documentProcessingPipeline.processAndWait(config)
+                            } catch {
+                                Logger.app.error("Background processing pipeline failed: \(error)")
                             }
                         }
                     }

--- a/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/DocumentDetails.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/DocumentDetails.swift
@@ -7,6 +7,7 @@
 
 import ArchiverModels
 import ComposableArchitecture
+import DocumentProcessingPipeline
 import Shared
 import SwiftUI
 
@@ -32,6 +33,8 @@ struct DocumentDetails {
         var shareDocument: ShareData?
 #endif
 
+        var isProcessingOCR = false
+
         @SharedReader(.highlightDetectedDateEnabled)
         var highlightDetectedDateEnabled: Bool
 
@@ -48,6 +51,8 @@ struct DocumentDetails {
         case onDeleteDocumentButtonTapped
         case onEditButtonTapped
         case onRemoteDocumentAppeared
+        case onTriggerManualOCR
+        case ocrProcessingCompleted
 #if os(iOS)
         case onShareButtonTapped
 #endif
@@ -64,6 +69,7 @@ struct DocumentDetails {
     }
 
     @Dependency(\.archiveStore.startDownloadOf) var startDownloadOf
+    @Dependency(\.documentProcessingPipeline) var documentProcessingPipeline
     var body: some ReducerOf<Self> {
         Scope(state: \.documentInformationForm, action: \.showDocumentInformationForm) {
             DocumentInformationForm()
@@ -128,6 +134,21 @@ struct DocumentDetails {
                 return .none
 #endif
 
+            case .onTriggerManualOCR:
+                state.isProcessingOCR = true
+                return .run { [url = state.document.url] send in
+                    let config = PipelineConfiguration(
+                        urls: [url],
+                        steps: [.ocr]
+                    )
+                    _ = await documentProcessingPipeline.processAndWait(config)
+                    await send(.ocrProcessingCompleted)
+                }
+
+            case .ocrProcessingCompleted:
+                state.isProcessingOCR = false
+                return .none
+
             case .showDocumentInformationForm:
                 return .none
 
@@ -142,8 +163,6 @@ struct DocumentDetails {
 
 struct DocumentDetailsView: View {
     @Bindable var store: StoreOf<DocumentDetails>
-    @SharedReader(.ocrEnabled) private var ocrEnabled: Bool
-
     var body: some View {
         Group {
             if store.document.downloadStatus < 1 {
@@ -211,14 +230,17 @@ struct DocumentDetailsView: View {
 
                 ToolbarSpacer()
 
-#if os(macOS)
-                if ocrEnabled,
-                   store.document.downloadStatus >= 1 {
+                if store.document.downloadStatus >= 1 {
                     ToolbarItem(id: "pdfInfo") {
-                        PDFInfoView(documentURL: store.document.url)
+                        PDFInfoView(
+                            documentURL: store.document.url,
+                            isProcessingOCR: store.isProcessingOCR,
+                            onTriggerOCR: {
+                                store.send(.onTriggerManualOCR)
+                            }
+                        )
                     }
                 }
-#endif
 
                 ToolbarItem(id: "share") {
 #if os(iOS)

--- a/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/PDFInfoView.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/PDFInfoView.swift
@@ -5,12 +5,15 @@
 //  Created by Julian Kahnert on 22.02.26.
 //
 
+import DocumentProcessingPipeline
 import PDFKit
 import Shared
 import SwiftUI
 
 struct PDFInfoView: View {
     let documentURL: URL
+    var isProcessingOCR: Bool = false
+    var onTriggerOCR: (() -> Void)?
 
     @State private var pdfInfo: PDFInfo?
     @State private var showPopover = false
@@ -28,9 +31,7 @@ struct PDFInfoView: View {
         }
 
         return PDFInfo(
-            hasTextLayer: (0..<min(pdf?.pageCount ?? 0, 3)).contains {
-                pdf?.page(at: $0)?.string?.isEmpty == false
-            },
+            hasTextLayer: PDFTextExtractor.extractText(from: url) != nil,
             pageCount: pdf?.pageCount ?? 0,
             fileSize: fileSize,
             creationDate: meta?[PDFDocumentAttribute.creationDateAttribute] as? Date,
@@ -45,17 +46,23 @@ struct PDFInfoView: View {
         Button {
             showPopover = true
         } label: {
-            Label(
-                pdfInfo?.hasTextLayer ?? true
-                    ? String(localized: "Searchable", bundle: #bundle)
-                    : String(localized: "Not searchable", bundle: #bundle),
-                systemImage: "info"
-            )
-            .foregroundStyle(pdfInfo?.hasTextLayer ?? true ? Color.primary : Color.red)
+            if isProcessingOCR {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Label(
+                    pdfInfo?.hasTextLayer ?? true
+                        ? String(localized: "Searchable", bundle: #bundle)
+                        : String(localized: "Not searchable", bundle: #bundle),
+                    systemImage: "info"
+                )
+                .foregroundStyle(pdfInfo?.hasTextLayer ?? true ? Color.primary : Color.red)
+            }
         }
+        .disabled(isProcessingOCR)
         .popover(isPresented: $showPopover) {
             if let info = pdfInfo {
-                PopoverView(info: info)
+                PopoverView(info: info, isProcessingOCR: isProcessingOCR, onTriggerOCR: onTriggerOCR)
             } else {
                 ProgressView()
                     .padding()
@@ -65,6 +72,15 @@ struct PDFInfoView: View {
             pdfInfo = await Task.detached(priority: .userInitiated) {
                 await Self.createPdfInfo(from: documentURL)
             }.value
+        }
+        .onChange(of: isProcessingOCR) { _, isProcessing in
+            guard !isProcessing else { return }
+            // Refresh PDF info after OCR completes
+            Task {
+                pdfInfo = await Task.detached(priority: .userInitiated) {
+                    await Self.createPdfInfo(from: documentURL)
+                }.value
+            }
         }
     }
 }
@@ -83,17 +99,36 @@ extension PDFInfoView {
 
     struct PopoverView: View {
         fileprivate let info: PDFInfo
+        var isProcessingOCR: Bool = false
+        var onTriggerOCR: (() -> Void)?
 
         var body: some View {
             VStack(alignment: .leading, spacing: 4) {
-                infoRow(
-                    label: String(localized: "OCR", bundle: #bundle),
-                    systemImage: info.hasTextLayer ? "checkmark.circle.fill" : "xmark.circle.fill",
-                    color: info.hasTextLayer ? .green : .red,
-                    value: info.hasTextLayer
-                        ? String(localized: "Available", bundle: #bundle)
-                        : String(localized: "Not available", bundle: #bundle)
-                )
+                HStack {
+                    Label(
+                        String(localized: "OCR", bundle: #bundle),
+                        systemImage: info.hasTextLayer ? "checkmark.circle.fill" : "xmark.circle.fill"
+                    )
+                    .foregroundStyle(info.hasTextLayer ? .green : .red)
+                    Spacer()
+                    if isProcessingOCR {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else if !info.hasTextLayer, let onTriggerOCR {
+                        Button(String(localized: "Run OCR", bundle: #bundle)) {
+                            onTriggerOCR()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    } else {
+                        Text(info.hasTextLayer
+                            ? String(localized: "Available", bundle: #bundle)
+                            : String(localized: "Not available", bundle: #bundle))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .multilineTextAlignment(.trailing)
+                    }
+                }
                 infoRow(
                     label: String(localized: "Pages", bundle: #bundle),
                     systemImage: "doc.text",

--- a/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/BackgroundTaskManager.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/BackgroundTaskManager.swift
@@ -8,6 +8,7 @@
 #if os(iOS)
 import BackgroundTasks
 import ComposableArchitecture
+import DocumentProcessingPipeline
 import Foundation
 import OSLog
 import Shared
@@ -24,10 +25,11 @@ public actor BackgroundTaskManager: Log {
 
     private static let scheduler = BGTaskScheduler.shared
 
-    @Dependency(\.contentExtractorStore) var contentExtractorStore
     @Dependency(\.archiveStore) var archiveStore
-    @Dependency(\.textAnalyser) var textAnalyser
-    @SharedReader(.appleIntelligenceCustomPrompt) var customPrompt: String?
+    @Dependency(\.documentProcessingPipeline) var documentProcessingPipeline
+    @SharedReader(.ocrEnabled) var ocrEnabled: Bool
+    @SharedReader(.appleIntelligenceEnabled) var aiEnabled: Bool
+    @SharedReader(.appleIntelligenceCacheEnabled) var aiCacheEnabled: Bool
     @SharedReader(.backgroundCacheNotificationsEnabled) var shouldNotify: Bool
 
     private init() {}
@@ -77,19 +79,33 @@ public actor BackgroundTaskManager: Log {
 
         do {
             let documents = try await archiveStore.getDocuments()
-            let newCachesCreated = await contentExtractorStore.processUntaggedDocumentsInBackground(
-                documents,
-                textAnalyser.getTextFrom,
-                customPrompt
+            var steps: Set<PipelineConfiguration.StepKind> = []
+            if ocrEnabled {
+                steps.insert(.ocr)
+            }
+            if aiEnabled && aiCacheEnabled {
+                steps.insert(.aiCache)
+            }
+
+            let untaggedURLs = documents.filter { !$0.isTagged }.map(\.url)
+            let config = PipelineConfiguration(
+                urls: untaggedURLs,
+                steps: steps
             )
+            let result = await documentProcessingPipeline.processAndWait(config)
 
             let processingDuration = Date().timeIntervalSince(startTime)
 
             if shouldNotify {
-                // Show local notification on success
                 let duration = Duration.seconds(processingDuration)
                 let durationText = duration.formatted(.units(width: .wide))
-                let body = "Created \(newCachesCreated) new cache\(newCachesCreated == 1 ? "" : "s") in \(durationText)."
+                let summary = result.stepResults
+                    .filter { $0.processedCount > 0 }
+                    .map { "\($0.step.rawValue): \($0.processedCount)" }
+                    .joined(separator: ", ")
+                let body = summary.isEmpty
+                    ? "No documents to process (\(durationText))."
+                    : "\(summary) in \(durationText)."
                 await UNUserNotificationCenter.current().showLocalNotification(
                     title: "Processing Completed",
                     body: body
@@ -97,7 +113,8 @@ public actor BackgroundTaskManager: Log {
             }
 
             task.setTaskCompleted(success: true)
-            Logger.backgroundTask.info("Background cache processing completed: \(newCachesCreated) caches in \(processingDuration)s")
+            let totalProcessed = result.stepResults.reduce(0) { $0 + $1.processedCount }
+            Logger.backgroundTask.info("Background processing completed: \(totalProcessed) documents in \(processingDuration)s")
         } catch {
             Logger.backgroundTask.error("Background cache processing failed: \(error)")
 
@@ -105,7 +122,7 @@ public actor BackgroundTaskManager: Log {
                 // Show local notification on failure
                 await UNUserNotificationCenter.current().showLocalNotification(
                     title: "Processing Failed",
-                    body: "Apple Intelligence cache processing failed: \(error.localizedDescription)"
+                    body: "Background processing failed: \(error.localizedDescription)"
                 )
             }
 

--- a/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/DocumentProcessingPipelineDependency.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/DocumentProcessingPipelineDependency.swift
@@ -1,0 +1,46 @@
+//
+//  DocumentProcessingPipelineDependency.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 22.02.26.
+//
+
+import ComposableArchitecture
+import DocumentProcessingPipeline
+import Foundation
+
+@DependencyClient
+struct DocumentProcessingPipelineDependency: Sendable {
+    var process: @Sendable (PipelineConfiguration) async -> AsyncStream<DocumentProcessingPipeline.StatusUpdate> = { _ in
+        AsyncStream { $0.finish() }
+    }
+    var processAndWait: @Sendable (PipelineConfiguration) async -> DocumentProcessingPipeline.Result = { _ in
+        .init(stepResults: [])
+    }
+}
+
+extension DocumentProcessingPipelineDependency: TestDependencyKey {
+    static let previewValue = Self()
+    static let testValue = Self()
+}
+
+extension DocumentProcessingPipelineDependency: DependencyKey {
+    static let liveValue: Self = {
+        let pipeline = DocumentProcessingPipeline()
+        return Self(
+            process: { config in
+                await pipeline.process(config)
+            },
+            processAndWait: { config in
+                await pipeline.processAndWait(config)
+            }
+        )
+    }()
+}
+
+extension DependencyValues {
+    var documentProcessingPipeline: DocumentProcessingPipelineDependency {
+        get { self[DocumentProcessingPipelineDependency.self] }
+        set { self[DocumentProcessingPipelineDependency.self] = newValue }
+    }
+}

--- a/ArchiverLib/Sources/ArchiverIntents/Views/UntaggedDocumentsStatsView.swift
+++ b/ArchiverLib/Sources/ArchiverIntents/Views/UntaggedDocumentsStatsView.swift
@@ -72,7 +72,7 @@ public struct UntaggedDocumentsStatsView: View {
                                 .foregroundStyle(.secondary)
                         }
                         .font(.caption)
-                        
+
                         Text(untaggedDocuments, format: .number)
                             .font(.system(size: 56, weight: .black))
                             .minimumScaleFactor(0.3)

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
@@ -113,56 +113,8 @@ public actor ContentExtractorStore: Log {
 
     /// Prune cache entries that don't have matching documents
     /// - Parameter validIds: Set of valid document IDs to keep in cache
-    private func pruneCache(keepingOnly validIds: Set<Document.ID>) async {
+    public func pruneCache(keepingOnly validIds: Set<Document.ID>) async {
         await cache.pruneCache(keepingOnly: validIds)
-    }
-
-    /// Process untagged documents in the background to create cache entries
-    /// This method should be called when the device is idle and connected to power
-    /// - Parameters:
-    ///   - documents: All documents to process
-    ///   - textExtractor: Closure to extract text from document URL
-    ///   - customPrompt: Optional custom prompt for extraction
-    public func processUntaggedDocumentsInBackground(documents: [Document], textExtractor: (URL) async -> String?, customPrompt: String?) async -> Int {
-        // Only process untagged documents
-        let untaggedDocuments = documents.filter { !$0.isTagged }
-
-        Logger.contentExtractor.info("Background cache processing started for \(untaggedDocuments.count) untagged documents")
-
-        var newCachesCreated = 0
-
-        for document in untaggedDocuments {
-            let documentId = document.id
-
-            // Skip if already cached
-            if await cache.getCachedResult(for: documentId) != nil {
-                continue
-            }
-
-            // Extract text and process (cache will be saved inside extract())
-            guard let text = await textExtractor(document.url) else {
-                continue
-            }
-
-            do {
-                _ = try await extract(from: text,
-                                     customPrompt: customPrompt,
-                                     with: documents,
-                                     documentId: documentId)
-                newCachesCreated += 1
-                Logger.contentExtractor.debug("Background cache entry created for document ID: \(documentId)")
-            } catch {
-                Logger.contentExtractor.error("Failed to create cache entry in background for document ID \(documentId): \(error)")
-            }
-        }
-
-        // Prune cache entries for documents that no longer exist in untagged folder
-        let untaggedIds = Set(untaggedDocuments.map(\.id))
-        await cache.pruneCache(keepingOnly: untaggedIds)
-
-        Logger.contentExtractor.info("Background cache processing completed: \(newCachesCreated) new caches created")
-
-        return newCachesCreated
     }
 
     // MARK: - internal helper functions

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStoreDependency.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStoreDependency.swift
@@ -67,13 +67,9 @@ public struct ContentExtractorStoreDependency: Sendable {
     /// - Parameter enabled: Whether cache should be enabled
     public var setCacheEnabled: @Sendable (Bool) async -> Void = { _ in }
 
-    /// Process untagged documents in background to create cache entries
-    /// - Parameters:
-    ///   - documents: All documents to process
-    ///   - textExtractor: Closure to extract text from document URL
-    ///   - customPrompt: Optional custom prompt for extraction
-    /// - Returns: Number of new cache entries created
-    public var processUntaggedDocumentsInBackground: @Sendable ([Document], @Sendable (URL) async -> String?, String?) async -> Int = { _, _, _ in 0 }
+    /// Prune cache entries that don't have matching documents
+    /// - Parameter validIds: Set of valid document IDs to keep in cache
+    public var pruneCache: @Sendable (Set<Document.ID>) async -> Void = { _ in }
 }
 
 extension ContentExtractorStoreDependency: TestDependencyKey {
@@ -83,7 +79,7 @@ extension ContentExtractorStoreDependency: TestDependencyKey {
         clearCache: {},
         getCacheCount: { 0 },
         setCacheEnabled: { _ in },
-        processUntaggedDocumentsInBackground: { _, _, _ in 0 }
+        pruneCache: { _ in }
     )
 
     public static let testValue = Self()
@@ -149,11 +145,9 @@ extension ContentExtractorStoreDependency: DependencyKey {
             guard #available(iOS 26.0, macOS 26.0, *) else { return }
             await contentExtractorStore.setCacheEnabled(enabled)
         },
-        processUntaggedDocumentsInBackground: { documents, textExtractor, customPrompt in
-            guard #available(iOS 26.0, macOS 26.0, *) else { return 0 }
-            return await contentExtractorStore.processUntaggedDocumentsInBackground(documents: documents,
-                                                                                    textExtractor: textExtractor,
-                                                                                    customPrompt: customPrompt)
+        pruneCache: { validIds in
+            guard #available(iOS 26.0, macOS 26.0, *) else { return }
+            await contentExtractorStore.pruneCache(keepingOnly: validIds)
         }
     )
 }

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/AICacheProcessingStep.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/AICacheProcessingStep.swift
@@ -1,0 +1,61 @@
+//
+//  AICacheProcessingStep.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 22.02.26.
+//
+
+import ArchiverModels
+import ArchiverStore
+import ContentExtractorStore
+import Dependencies
+import Foundation
+import OSLog
+import Shared
+import Sharing
+
+/// Pre-caches AI-generated descriptions and tags for documents.
+/// Uses archiveStore and contentExtractorStore dependencies directly.
+/// Expects only untagged document URLs — filtering must happen before calling this step.
+struct AICacheProcessingStep: PipelineStep, Sendable {
+    let kind: PipelineConfiguration.StepKind = .aiCache
+
+    @Dependency(\.archiveStore) var archiveStore
+    @Dependency(\.contentExtractorStore) var contentExtractorStore
+    @SharedReader(.appleIntelligenceCustomPrompt) var customPrompt: String?
+
+    func process(urls: [URL], config: PipelineConfiguration, onProcessed: @Sendable (URL) -> Void) async -> Int {
+        let documents: [Document]
+        do {
+            documents = try await archiveStore.getDocuments()
+        } catch {
+            Logger.aiCacheStep.error("AI Cache step failed to fetch documents: \(error)")
+            return 0
+        }
+
+        let documentsByURL = Dictionary(uniqueKeysWithValues: documents.compactMap { doc in
+            (doc.url, doc)
+        })
+
+        // Documents are processed sequentially because Apple Intelligence
+        // does not support concurrent requests (returns a concurrentRequests error).
+        var processedCount = 0
+        for url in urls {
+            guard let doc = documentsByURL[url] else { continue }
+            guard let text = PDFTextExtractor.extractText(from: url) else { continue }
+            let result = await contentExtractorStore.getDocumentInformation(
+                .init(currentDocuments: documents, text: text, customPrompt: customPrompt, documentId: doc.id)
+            )
+            if result != nil {
+                processedCount += 1
+                onProcessed(url)
+            }
+        }
+
+        // Prune cache entries for documents that no longer exist
+        let validIds = Set(urls.compactMap { documentsByURL[$0]?.id })
+        await contentExtractorStore.pruneCache(validIds)
+
+        return processedCount
+    }
+}

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/DocumentProcessingPipeline.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/DocumentProcessingPipeline.swift
@@ -1,0 +1,93 @@
+//
+//  DocumentProcessingPipeline.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 22.02.26.
+//
+
+import Foundation
+import OSLog
+
+/// Orchestrates sequential execution of document processing steps
+public actor DocumentProcessingPipeline {
+
+    /// Status update emitted per processed URL
+    public struct StatusUpdate: Sendable {
+        public let url: URL
+        public let step: PipelineConfiguration.StepKind
+
+        public init(url: URL, step: PipelineConfiguration.StepKind) {
+            self.url = url
+            self.step = step
+        }
+    }
+
+    /// Final result from a pipeline run
+    public struct Result: Sendable {
+        public let stepResults: [StepResult]
+
+        public init(stepResults: [StepResult]) {
+            self.stepResults = stepResults
+        }
+    }
+
+    /// Result from a single pipeline step
+    public struct StepResult: Sendable {
+        public let step: PipelineConfiguration.StepKind
+        public let processedCount: Int
+
+        public init(step: PipelineConfiguration.StepKind, processedCount: Int) {
+            self.step = step
+            self.processedCount = processedCount
+        }
+    }
+
+    private let steps: [any PipelineStep]
+
+    public init() {
+        self.steps = [
+            OCRProcessingStep(),
+            AICacheProcessingStep()
+        ]
+    }
+
+    /// Mode 1: Fire-and-forget with status stream
+    public func process(_ config: PipelineConfiguration) -> AsyncStream<StatusUpdate> {
+        AsyncStream { continuation in
+            Task {
+                _ = await runSteps(config: config) { update in
+                    continuation.yield(update)
+                }
+                continuation.finish()
+            }
+        }
+    }
+
+    /// Mode 2: Await result
+    public func processAndWait(_ config: PipelineConfiguration) async -> Result {
+        await runSteps(config: config, onUpdate: nil)
+    }
+
+    // MARK: - Private
+
+    private func runSteps(config: PipelineConfiguration, onUpdate: (@Sendable (StatusUpdate) -> Void)?) async -> Result {
+        var stepResults: [StepResult] = []
+
+        for step in steps {
+            guard !Task.isCancelled else { break }
+            guard config.steps.contains(step.kind) else {
+                Logger.pipeline.info("Pipeline step '\(step.kind.rawValue)' not in config, skipping")
+                continue
+            }
+
+            Logger.pipeline.info("Pipeline step '\(step.kind.rawValue)' starting")
+            let count = await step.process(urls: config.urls, config: config) { url in
+                onUpdate?(StatusUpdate(url: url, step: step.kind))
+            }
+            stepResults.append(StepResult(step: step.kind, processedCount: count))
+            Logger.pipeline.info("Pipeline step '\(step.kind.rawValue)' completed: \(count) documents processed")
+        }
+
+        return Result(stepResults: stepResults)
+    }
+}

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/DocumentProcessingStep.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/DocumentProcessingStep.swift
@@ -1,0 +1,57 @@
+//
+//  PipelineTypes.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 22.02.26.
+//
+
+import Foundation
+
+/// Configuration for a pipeline run
+public struct PipelineConfiguration: Sendable {
+    /// PDF file URLs to process
+    public let urls: [URL]
+
+    /// Which steps to execute
+    public let steps: Set<StepKind>
+
+    public init(
+        urls: [URL],
+        steps: Set<StepKind>
+    ) {
+        self.urls = urls
+        self.steps = steps
+    }
+
+    /// Available processing steps
+    public enum StepKind: String, Sendable, Hashable, CaseIterable {
+        case ocr
+        case aiCache
+    }
+}
+
+/// A single processing step that the ``DocumentProcessingPipeline`` executes.
+///
+/// Each step declares which ``PipelineConfiguration/StepKind`` it handles and
+/// provides a ``process(urls:config:onProcessed:)`` method that performs the
+/// actual work on a list of document URLs.
+///
+/// Conforming types must be `Sendable` because steps may be executed
+/// concurrently by the pipeline.
+protocol PipelineStep: Sendable {
+    /// The kind of processing this step performs.
+    ///
+    /// The pipeline uses this value to decide whether the step should run
+    /// for a given ``PipelineConfiguration``.
+    var kind: PipelineConfiguration.StepKind { get }
+
+    /// Process the given document URLs.
+    ///
+    /// - Parameters:
+    ///   - urls: The document URLs to process.
+    ///   - config: The pipeline configuration for the current run.
+    ///   - onProcessed: A callback invoked once per successfully processed URL,
+    ///     allowing the pipeline to emit progress updates.
+    /// - Returns: The number of documents that were successfully processed.
+    func process(urls: [URL], config: PipelineConfiguration, onProcessed: @Sendable (URL) -> Void) async -> Int
+}

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/Log.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/Log.swift
@@ -1,0 +1,16 @@
+//
+//  Log.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 01.03.26.
+//
+
+import OSLog
+
+extension Logger {
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "de.JulianKahnert.PDFArchiveViewer"
+
+    static let pipeline = Logger(subsystem: subsystem, category: "processing-pipeline")
+    static let ocrStep = Logger(subsystem: subsystem, category: "ocr-step")
+    static let aiCacheStep = Logger(subsystem: subsystem, category: "ai-cache-step")
+}

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/OCRProcessingStep.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/OCRProcessingStep.swift
@@ -1,0 +1,28 @@
+//
+//  OCRProcessingStep.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 22.02.26.
+//
+
+import Foundation
+
+/// Pipeline step that delegates to ``PDFOCRProcessor`` for each URL.
+struct OCRProcessingStep: PipelineStep, Sendable {
+    let kind: PipelineConfiguration.StepKind = .ocr
+
+    func process(urls: [URL], config: PipelineConfiguration, onProcessed: @Sendable (URL) -> Void) async -> Int {
+        var processedCount = 0
+
+        for url in urls {
+            guard !Task.isCancelled else { break }
+
+            if await PDFOCRProcessor.processOCR(url: url) {
+                processedCount += 1
+                onProcessed(url)
+            }
+        }
+
+        return processedCount
+    }
+}

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/PDFOCRProcessor.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/PDFOCRProcessor.swift
@@ -1,0 +1,197 @@
+//
+//  PDFOCRProcessor.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 02.03.26.
+//
+
+import Foundation
+import OSLog
+import PDFKit
+import Vision
+
+#if canImport(UIKit)
+import UIKit
+private typealias PlatformColor = UIColor
+private typealias PlatformFont = UIFont
+#else
+import AppKit
+private typealias PlatformColor = NSColor
+private typealias PlatformFont = NSFont
+#endif
+
+/// Recognized text with its bounding box in normalized coordinates.
+struct RecognizedText: Sendable {
+    let text: String
+    let boundingBox: CGRect
+}
+
+/// Adds an invisible text layer to image-only PDFs using Vision framework OCR.
+///
+/// This processor can be used standalone (e.g. from the `ocr-tool` CLI)
+/// or as part of the ``DocumentProcessingPipeline`` via ``OCRProcessingStep``.
+public enum PDFOCRProcessor {
+
+    /// Performs OCR on a PDF at the given URL if it lacks a text layer.
+    /// Modified pages receive invisible text annotations for searchability.
+    /// - Parameter url: The PDF file URL to process.
+    /// - Returns: `true` if the file was modified and saved.
+    public static func processOCR(url: URL) async -> Bool {
+        guard let pdfDocument = PDFDocument(url: url) else { return false }
+        if PDFTextExtractor.extractText(from: url) != nil { return false }
+        guard let ocrDocument = await performOCR(on: pdfDocument) else { return false }
+
+        do {
+            try replaceFile(at: url, with: ocrDocument)
+            Logger.ocrStep.info("OCR completed for: \(url.lastPathComponent)")
+            return true
+        } catch {
+            Logger.ocrStep.error("OCR file replacement failed for \(url.lastPathComponent): \(error)")
+            return false
+        }
+    }
+
+    /// Performs OCR on a PDF at the given URL and reports per-page progress.
+    /// - Parameters:
+    ///   - url: The PDF file URL to process.
+    ///   - onPage: Callback with (pageIndex, pageCount, recognizedRegions) per processed page.
+    /// - Returns: `true` if the file was modified and saved.
+    public static func processOCR(
+        url: URL,
+        onPage: (Int, Int, Int) -> Void
+    ) async -> Bool {
+        guard let pdfDocument = PDFDocument(url: url) else { return false }
+        if PDFTextExtractor.extractText(from: url) != nil { return false }
+
+        var pagesModified = 0
+        let pageCount = pdfDocument.pageCount
+
+        for pageIndex in 0..<pageCount {
+            guard !Task.isCancelled else { return false }
+            guard let page = pdfDocument.page(at: pageIndex) else { continue }
+
+            if let text = page.string,
+               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                continue
+            }
+
+            let pageBounds = page.bounds(for: .mediaBox)
+            guard let cgImage = renderPageToImage(page, bounds: pageBounds) else { continue }
+
+            let observations = await recognizeText(in: cgImage)
+            guard !observations.isEmpty else { continue }
+
+            addTextOverlay(to: page, bounds: pageBounds, observations: observations)
+            pagesModified += 1
+            onPage(pageIndex, pageCount, observations.count)
+        }
+
+        guard pagesModified > 0 else { return false }
+
+        do {
+            try replaceFile(at: url, with: pdfDocument)
+            return true
+        } catch {
+            Logger.ocrStep.error("OCR file replacement failed for \(url.lastPathComponent): \(error)")
+            return false
+        }
+    }
+
+    // MARK: - Internal
+
+    static func performOCR(on pdf: PDFDocument) async -> PDFDocument? {
+        var pagesModified = 0
+
+        for pageIndex in 0..<pdf.pageCount {
+            guard !Task.isCancelled else { return nil }
+            guard let page = pdf.page(at: pageIndex) else { continue }
+
+            if let text = page.string,
+               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                continue
+            }
+
+            let pageBounds = page.bounds(for: .mediaBox)
+            guard let cgImage = renderPageToImage(page, bounds: pageBounds) else { continue }
+
+            let observations = await recognizeText(in: cgImage)
+            guard !observations.isEmpty else { continue }
+
+            addTextOverlay(to: page, bounds: pageBounds, observations: observations)
+            pagesModified += 1
+        }
+
+        return pagesModified > 0 ? pdf : nil
+    }
+
+    static func renderPageToImage(_ page: PDFPage, bounds: CGRect) -> CGImage? {
+        let scale: CGFloat = 2.0
+        let width = Int(bounds.width * scale)
+        let height = Int(bounds.height * scale)
+
+        guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+              let context = CGContext(
+                  data: nil,
+                  width: width,
+                  height: height,
+                  bitsPerComponent: 8,
+                  bytesPerRow: 0,
+                  space: colorSpace,
+                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else { return nil }
+
+        context.scaleBy(x: scale, y: scale)
+
+        #if canImport(UIKit)
+        context.translateBy(x: 0, y: bounds.height)
+        context.scaleBy(x: 1, y: -1)
+        #endif
+
+        page.draw(with: .mediaBox, to: context)
+        return context.makeImage()
+    }
+
+    static func recognizeText(in image: CGImage) async -> [RecognizedText] {
+        do {
+            var request = RecognizeTextRequest()
+            request.recognitionLevel = .accurate
+            request.usesLanguageCorrection = true
+
+            let observations = try await request.perform(on: image)
+            return observations.compactMap { observation -> RecognizedText? in
+                guard let candidate = observation.topCandidates(1).first else { return nil }
+                return RecognizedText(text: candidate.string, boundingBox: observation.boundingBox.cgRect)
+            }
+        } catch {
+            Logger.ocrStep.error("Text recognition failed: \(error)")
+            return []
+        }
+    }
+
+    static func addTextOverlay(to page: PDFPage, bounds: CGRect, observations: [RecognizedText]) {
+        for observation in observations {
+            let rect = CGRect(
+                x: observation.boundingBox.origin.x * bounds.width,
+                y: observation.boundingBox.origin.y * bounds.height,
+                width: observation.boundingBox.width * bounds.width,
+                height: observation.boundingBox.height * bounds.height
+            )
+
+            let annotation = PDFAnnotation(bounds: rect, forType: .freeText, withProperties: nil)
+            annotation.contents = observation.text
+            annotation.font = PlatformFont.systemFont(ofSize: rect.height * 0.8)
+            annotation.fontColor = PlatformColor.clear
+            annotation.color = PlatformColor.clear
+            annotation.isReadOnly = true
+            page.addAnnotation(annotation)
+        }
+    }
+
+    private static func replaceFile(at originalURL: URL, with document: PDFDocument) throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("pdf")
+        document.write(to: tempURL)
+        _ = try FileManager.default.replaceItemAt(originalURL, withItemAt: tempURL)
+    }
+}

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/PDFTextExtractor.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/PDFTextExtractor.swift
@@ -1,0 +1,28 @@
+//
+//  PDFTextExtractor.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 01.03.26.
+//
+
+import Foundation
+import PDFKit
+
+/// Built-in PDF text extraction utility
+public enum PDFTextExtractor {
+    /// Extract text from the first pages of a PDF
+    /// - Parameters:
+    ///   - url: PDF file URL
+    ///   - maxPages: Maximum number of pages to extract (default: 3)
+    /// - Returns: Extracted text, or nil if no text found
+    public static func extractText(from url: URL, maxPages: Int = 3) -> String? {
+        guard let pdf = PDFDocument(url: url) else { return nil }
+        var text = ""
+        for pageIndex in 0..<min(pdf.pageCount, maxPages) {
+            guard let page = pdf.page(at: pageIndex),
+                  let content = page.string else { continue }
+            text += content
+        }
+        return text.isEmpty ? nil : text
+    }
+}

--- a/ArchiverLib/Sources/Shared/Log.swift
+++ b/ArchiverLib/Sources/Shared/Log.swift
@@ -32,6 +32,7 @@ nonisolated public extension Logger {
     static let backgroundTask = Logger(subsystem: subsystem, category: "background-task")
     static let contentExtractor = Logger(subsystem: subsystem, category: "content-extractor")
     static let documentProcessing = Logger(subsystem: subsystem, category: "document-processing")
+    static let processingPipeline = Logger(subsystem: subsystem, category: "processing-pipeline")
     static let inAppPurchase = Logger(subsystem: subsystem, category: "in-app-purchase")
     static let navigationModel = Logger(subsystem: subsystem, category: "navigation-model")
     static let newDocument = Logger(subsystem: subsystem, category: "new-document")

--- a/ArchiverLib/Sources/ocr-tool/main.swift
+++ b/ArchiverLib/Sources/ocr-tool/main.swift
@@ -1,0 +1,46 @@
+//
+//  main.swift
+//  ocr-tool
+//
+//  CLI tool that adds an invisible text layer to image-only PDFs.
+//  Uses the same OCR logic as the PDF Archiver app.
+//
+//  Usage: swift run ocr-tool <path-to-pdf>
+//  Build: swift build --product ocr-tool
+//
+
+import DocumentProcessingPipeline
+import Foundation
+
+guard CommandLine.arguments.count == 2 else {
+    print("Usage: ocr-tool <path-to-pdf>")
+    exit(1)
+}
+
+let path = CommandLine.arguments[1]
+let url = URL(fileURLWithPath: path)
+
+guard FileManager.default.fileExists(atPath: path) else {
+    print("Error: File not found: \(path)")
+    exit(1)
+}
+
+print("Processing \(url.lastPathComponent)...")
+
+let semaphore = DispatchSemaphore(value: 0)
+
+Task {
+    let success = await PDFOCRProcessor.processOCR(url: url) { pageIndex, pageCount, regions in
+        print("  Page \(pageIndex + 1)/\(pageCount): \(regions) text regions added")
+    }
+
+    if success {
+        print("Done: OCR text layer added to \(path)")
+    } else {
+        print("No changes: PDF already has text or no text was recognized.")
+    }
+
+    semaphore.signal()
+}
+
+semaphore.wait()

--- a/ArchiverLib/Tests/DocumentProcessingPipelineTests/DocumentProcessingPipelineTests.swift
+++ b/ArchiverLib/Tests/DocumentProcessingPipelineTests/DocumentProcessingPipelineTests.swift
@@ -1,0 +1,169 @@
+//
+//  DocumentProcessingPipelineTests.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 22.02.26.
+//
+
+import ContentExtractorStore
+import Dependencies
+@testable import DocumentProcessingPipeline
+import Foundation
+import Testing
+
+@Suite
+struct DocumentProcessingPipelineTests {
+
+    private func makeConfig(
+        urls: [URL] = [],
+        steps: Set<PipelineConfiguration.StepKind> = [.ocr, .aiCache]
+    ) -> PipelineConfiguration {
+        PipelineConfiguration(
+            urls: urls,
+            steps: steps
+        )
+    }
+
+    @Test
+    func processAndWaitRunsOCRStep() async {
+        let pipeline = DocumentProcessingPipeline()
+        let config = makeConfig(steps: [.ocr])
+        let result = await pipeline.processAndWait(config)
+
+        // OCR step runs but no URLs to process
+        #expect(result.stepResults.count == 1)
+        #expect(result.stepResults[0].step == .ocr)
+        #expect(result.stepResults[0].processedCount == 0)
+    }
+
+    @Test
+    func processAndWaitSkipsStepsNotInConfig() async {
+        let pipeline = DocumentProcessingPipeline()
+        // Only request OCR, AI cache should be skipped
+        let config = makeConfig(steps: [.ocr])
+        let result = await pipeline.processAndWait(config)
+
+        #expect(result.stepResults.count == 1)
+        #expect(result.stepResults[0].step == .ocr)
+    }
+
+    @Test
+    func processAndWaitRunsAICacheStep() async {
+        await withDependencies {
+            $0.archiveStore.getDocuments = { [] }
+            $0.contentExtractorStore.pruneCache = { _ in }
+        } operation: {
+            let pipeline = DocumentProcessingPipeline()
+            let config = makeConfig(steps: [.aiCache])
+            let result = await pipeline.processAndWait(config)
+
+            #expect(result.stepResults.count == 1)
+            #expect(result.stepResults[0].step == .aiCache)
+            #expect(result.stepResults[0].processedCount == 0)
+        }
+    }
+
+    @Test
+    func processEmitsStatusUpdates() async {
+        let pipeline = DocumentProcessingPipeline()
+        let config = makeConfig(steps: [.ocr])
+
+        var updates: [DocumentProcessingPipeline.StatusUpdate] = []
+        for await update in await pipeline.process(config) {
+            updates.append(update)
+        }
+
+        // No URLs means no status updates
+        #expect(updates.isEmpty)
+    }
+
+    @Test
+    func processAndWaitReturnsEmptyForNoSteps() async {
+        let pipeline = DocumentProcessingPipeline()
+        let config = makeConfig(steps: [])
+        let result = await pipeline.processAndWait(config)
+
+        #expect(result.stepResults.isEmpty)
+    }
+
+    @Test
+    func pdfTextExtractorDetectsText() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".pdf")
+        let pdf = createPDFWithText("Hello World")
+        try #require(pdf.write(to: url))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(PDFTextExtractor.extractText(from: url) != nil)
+    }
+
+    @Test
+    func pdfTextExtractorReturnsNilForBlankPDF() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".pdf")
+        let pdf = createBlankPDF()
+        try #require(pdf.write(to: url))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(PDFTextExtractor.extractText(from: url) == nil)
+    }
+
+    @Test
+    func pdfTextExtractorReturnsNilForNonexistentFile() {
+        let result = PDFTextExtractor.extractText(from: URL(fileURLWithPath: "/nonexistent.pdf"))
+        #expect(result == nil)
+    }
+}
+
+// MARK: - Test Helpers
+
+import PDFKit
+
+private func createPDFWithText(_ text: String) -> PDFDocument {
+    let data = NSMutableData()
+    var bounds = CGRect(x: 0, y: 0, width: 612, height: 792)
+    guard let consumer = CGDataConsumer(data: data),
+          let context = CGContext(consumer: consumer, mediaBox: &bounds, nil) else {
+        fatalError("Failed to create PDF context")
+    }
+
+    context.beginPDFPage(nil)
+
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: platformFont(size: 12)
+    ]
+    let attributedString = NSAttributedString(string: text, attributes: attributes)
+    let line = CTLineCreateWithAttributedString(attributedString)
+    context.textPosition = CGPoint(x: 50, y: 700)
+    CTLineDraw(line, context)
+
+    context.endPDFPage()
+    context.closePDF()
+
+    return PDFDocument(data: data as Data) ?? PDFDocument()
+}
+
+private func createBlankPDF() -> PDFDocument {
+    let data = NSMutableData()
+    var bounds = CGRect(x: 0, y: 0, width: 612, height: 792)
+    guard let consumer = CGDataConsumer(data: data),
+          let context = CGContext(consumer: consumer, mediaBox: &bounds, nil) else {
+        fatalError("Failed to create PDF context")
+    }
+
+    context.beginPDFPage(nil)
+    context.endPDFPage()
+    context.closePDF()
+
+    return PDFDocument(data: data as Data) ?? PDFDocument()
+}
+
+#if canImport(UIKit)
+import UIKit
+private func platformFont(size: CGFloat) -> UIFont {
+    UIFont.systemFont(ofSize: size)
+}
+#else
+import AppKit
+private func platformFont(size: CGFloat) -> NSFont {
+    NSFont.systemFont(ofSize: size)
+}
+#endif

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,20 @@ swift build --triple arm64-apple-macosx      # Apple Silicon
 swift build --triple x86_64-apple-macosx     # Intel
 ```
 
+### Fixing Macro Build Errors
+
+If `xcodebuild` fails with `Unable to find module dependency: 'SwiftSyntax'` or similar macro plugin errors, run the CI post-clone script to register macro fingerprints:
+
+```bash
+cd ci_scripts && bash ci_post_clone.sh && cd ..
+```
+
+If the error persists, clean DerivedData:
+
+```bash
+rm -rf ~/Library/Developer/Xcode/DerivedData/PDFArchiver-*
+```
+
 ### Localization Workflow
 
 **CRITICAL**: Always check and update localizations before committing any code changes.


### PR DESCRIPTION
## Changes

- Add `DocumentProcessingPipeline` SPM target with step protocol, pipeline actor, OCR step, and AI cache step
- `OCRProcessingStep`: checks PDFs for text layer; if image-only, renders pages via PDFKit, runs Vision OCR, writes invisible-text overlay back to file atomically
- `AICacheProcessingStep`: delegates to `ContentExtractorStore` for Apple Intelligence tagging suggestions (iOS 26+/macOS 26+ only)
- `DocumentProcessingPipelineDependency`: TCA dependency with `run(context:)` and `runOCROnDocument(_:)` endpoints
- `DocumentProcessingPipelineTests`: 6 unit tests covering step sequencing, skip-disabled, context passing, and PDF text detection
- Update `BackgroundTaskManager` and `AppFeature` to use the new pipeline instead of direct `ContentExtractorStore` calls
- Wire `triggerManualOCR` delegate from `DocumentInformationForm` through `DocumentDetails` to the pipeline

## Notes

- Stacks on top of PR #261 (`feature/text-layer-indicator-toolbar`)
- `ocrEnabled` shared key drives both the `OCRProcessingStep.isEnabled` and the toolbar indicator from PR #261
- No `@available(iOS 26, *)` gate on the pipeline itself — only `AICacheProcessingStep` carries the availability guard

Closes #259