### PR TITLE
feat(ui): improve widget layout and add context menu to PDFInfoView

### DIFF
--- a/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/PDFInfoView.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/PDFInfoView.swift
@@ -61,6 +61,58 @@ struct PDFInfoView: View {
                     .padding()
             }
         }
+        .contextMenu(menuItems: {
+            if let info = pdfInfo {
+                Label(
+                    "\(String(localized: "OCR", bundle: #bundle)): \(info.hasTextLayer ? String(localized: "Available", bundle: #bundle) : String(localized: "Not available", bundle: #bundle))",
+                    systemImage: info.hasTextLayer ? "checkmark.circle.fill" : "xmark.circle.fill"
+                )
+                Label(
+                    "\(String(localized: "Pages", bundle: #bundle)): \(info.pageCount)",
+                    systemImage: "doc.text"
+                )
+                if let fileSize = info.fileSize {
+                    Label(
+                        "\(String(localized: "File Size", bundle: #bundle)): \(fileSize)",
+                        systemImage: "internaldrive"
+                    )
+                }
+                if let title = info.title {
+                    Label(
+                        "\(String(localized: "Title", bundle: #bundle)): \(title)",
+                        systemImage: "textformat"
+                    )
+                }
+                if let author = info.author {
+                    Label(
+                        "\(String(localized: "Author", bundle: #bundle)): \(author)",
+                        systemImage: "person"
+                    )
+                }
+                if let subject = info.subject {
+                    Label(
+                        "\(String(localized: "Subject", bundle: #bundle)): \(subject)",
+                        systemImage: "tag"
+                    )
+                }
+                if let date = info.creationDate {
+                    Label(
+                        "\(String(localized: "Created", bundle: #bundle)): \(date.formatted(date: .abbreviated, time: .shortened))",
+                        systemImage: "calendar"
+                    )
+                }
+                if let date = info.modificationDate {
+                    Label(
+                        "\(String(localized: "Modified", bundle: #bundle)): \(date.formatted(date: .abbreviated, time: .shortened))",
+                        systemImage: "calendar.badge.clock"
+                    )
+                }
+            }
+        }, preview: {
+            if let info = pdfInfo {
+                PopoverView(info: info)
+            }
+        })
         .task(id: documentURL) {
             pdfInfo = await Task.detached(priority: .userInitiated) {
                 await Self.createPdfInfo(from: documentURL)

--- a/ArchiverLib/Sources/ArchiverIntents/Views/UntaggedDocumentsStatsView.swift
+++ b/ArchiverLib/Sources/ArchiverIntents/Views/UntaggedDocumentsStatsView.swift
@@ -62,19 +62,22 @@ public struct UntaggedDocumentsStatsView: View {
         case .small:
             VStack(alignment: .leading) {
                 if untaggedDocuments > 0 {
-                    VStack(spacing: 8) {
-                        HStack(alignment: .bottom, spacing: 8) {
-                            Text(untaggedDocuments, format: .number)
-                                .fontWeight(.black)
-                                .foregroundStyle(.primary)
-                                .minimumScaleFactor(0.5)
-                                .lineLimit(1)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(untaggedDocuments, format: .number)
+                            .font(.system(size: 56, weight: .black))
+                            .minimumScaleFactor(0.3)
+                            .lineLimit(1)
+                            .foregroundStyle(.primary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
+                        HStack(spacing: 4) {
                             Image(systemName: "document.on.document")
                                 .foregroundStyle(Color.paRedAsset)
                                 .symbolRenderingMode(.hierarchical)
+                            Text("Untagged", bundle: #bundle)
+                                .foregroundStyle(.secondary)
                         }
-                        .font(.largeTitle)
+                        .font(.caption)
                     }
                 } else {
                     allDocumentsTagged


### PR DESCRIPTION
## Changes
- Fix untagged documents widget (small size): number now on its own line (56pt, scales down), icon + "Untagged" label on second line
- Add `contextMenu(menuItems:preview:)` to `PDFInfoView` toolbar button: long-press shows all PDF details (OCR, pages, file size, title, author, subject, dates) with `PopoverView` as preview