### PR TITLE
Fix widget family detection

### DIFF
--- a/Widget/StatsWidget.swift
+++ b/Widget/StatsWidget.swift
@@ -74,17 +74,25 @@ extension StatsView.Size {
     }
 }
 
-struct StatsWidget: Widget {
+private struct StatsEntryView: View {
     @Environment(\.widgetFamily) var widgetFamily
+    let entry: StatsEntry
+
+    var body: some View {
+        StatsView(yearStats: entry.yearStats,
+                  size: .create(from: widgetFamily))
+            .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+struct StatsWidget: Widget {
     let kind: String = "StatsWidget"
 
     var body: some WidgetConfiguration {
         AppIntentConfiguration(kind: kind,
                                intent: ConfigurationAppIntent.self,
                                provider: StatsProvider()) { entry in
-            StatsView(yearStats: entry.yearStats,
-                      size: .create(from: widgetFamily))
-                .containerBackground(.fill.tertiary, for: .widget)
+            StatsEntryView(entry: entry)
         }
         .configurationDisplayName("PDF Statistics")
         .description("Number of PDFs per year in your archive.")

--- a/Widget/UntaggedDocumentsWidget.swift
+++ b/Widget/UntaggedDocumentsWidget.swift
@@ -58,16 +58,24 @@ extension UntaggedDocumentsStatsView.Size {
     }
 }
 
-struct UntaggedDocumentsWidget: Widget {
+private struct UntaggedDocumentsEntryView: View {
     @Environment(\.widgetFamily) var widgetFamily
+    let entry: UntaggedDocumentsEntry
+
+    var body: some View {
+        UntaggedDocumentsStatsView(untaggedDocuments: entry.untaggedDocuments,
+                                   size: .create(from: widgetFamily))
+            .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+struct UntaggedDocumentsWidget: Widget {
     let kind: String = "UntaggedDocumentsWidget"
 
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind,
                             provider: UntaggedDocumentsProvider()) { entry in
-            UntaggedDocumentsStatsView(untaggedDocuments: entry.untaggedDocuments,
-                                  size: .create(from: widgetFamily))
-                .containerBackground(.fill.tertiary, for: .widget)
+            UntaggedDocumentsEntryView(entry: entry)
         }
         .configurationDisplayName("Untagged Documents")
         .description("See how many documents are currently untagged or scan a new document.")


### PR DESCRIPTION
## Changes
- Moved `@Environment(\.widgetFamily)` from Widget structs into dedicated entry Views
- Affects both `UntaggedDocumentsWidget` and `StatsWidget`

## Problem
`@Environment(\.widgetFamily)` on a `Widget` struct never receives the actual widget family from WidgetKit — it only works inside SwiftUI `View`s. This caused both widgets to always render the wrong size layout (small widget showed medium layout).

This is why the fixes from #252 had no visible effect.

## Fix
Created `UntaggedDocumentsEntryView` and `StatsEntryView` wrapper views that read `widgetFamily` from the environment and pass the correct size to the content views.

Fixes #251