### PR TITLE
fix: resolve Swift concurrency issues

### DIFF
--- a/ArchiverLib/Sources/ArchiverDocumentProcessing/DocumentProcessingService.swift
+++ b/ArchiverLib/Sources/ArchiverDocumentProcessing/DocumentProcessingService.swift
@@ -56,7 +56,7 @@ public final class DocumentProcessingService: Sendable {
         }
         let operation = PDFProcessingOperation(of: .pdf(pdfData: pdfData, url: url), destinationFolder: destinationFolder, onComplete: { documentUrl in
             Task {
-                self.lastProcessedDocumentUrl = documentUrl
+                self.lastProcessedDocumentUrl = documentUrl ?? self.lastProcessedDocumentUrl
             }
         })
         backgroundProcessing.queue(operation)

--- a/ArchiverLib/Sources/ArchiverDocumentProcessing/PDFProcessing.swift
+++ b/ArchiverLib/Sources/ArchiverDocumentProcessing/PDFProcessing.swift
@@ -35,10 +35,10 @@ final class PDFProcessingOperation: AsyncOperation {
 
     private let mode: Mode
     private let destinationFolder: URL
-    private let onComplete: (_ createdDocumentUrl: URL) -> Void
+    private let onComplete: (_ createdDocumentUrl: URL?) -> Void
     private var tempUrls: [URL] = []
 
-    init(of mode: Mode, destinationFolder: URL, onComplete: @StorageActor @escaping (_ createdDocumentUrl: URL) -> Void) {
+    init(of mode: Mode, destinationFolder: URL, onComplete: @StorageActor @escaping (_ createdDocumentUrl: URL?) -> Void) {
         self.mode = mode
         self.destinationFolder = destinationFolder
         self.onComplete = onComplete
@@ -101,6 +101,7 @@ final class PDFProcessingOperation: AsyncOperation {
             onComplete(filepath)
         } catch {
             Logger.documentProcessing.errorAndAssert("An error occurred while processing", metadata: ["error": "\(error)"])
+            onComplete(nil)
         }
     }
 

--- a/ArchiverLib/Sources/ArchiverFeatures/AppFeature/AppFeature.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/AppFeature/AppFeature.swift
@@ -365,10 +365,6 @@ struct AppView: View {
 
     init(store: StoreOf<AppFeature>) {
         self.store = store
-
-        Task.detached(priority: .background) {
-            await store.send(.onLongBackgroundTask).finish()
-        }
     }
 
     var body: some View {
@@ -429,6 +425,9 @@ struct AppView: View {
             .hidden(horizontalSizeClass == .compact)
         }
         .tabViewStyle(.sidebarAdaptable)
+        .task {
+            await store.send(.onLongBackgroundTask).finish()
+        }
         .apply { content in
             #if os(iOS)
             if #available(iOS 26.0, *) {

--- a/ArchiverLib/Sources/ArchiverFeatures/DocumentInformationForm/DocumentInformationForm.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/DocumentInformationForm/DocumentInformationForm.swift
@@ -425,6 +425,7 @@ struct DocumentInformationFormView: View {
             .overlay(alignment: .trailing) {
                 if store.isLoading {
                     ProgressView()
+                        .controlSize(.small)
                 }
             }
         }

--- a/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/BackgroundTaskManager.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/BackgroundTaskManager.swift
@@ -69,20 +69,24 @@ public actor BackgroundTaskManager: Log {
         Logger.backgroundTask.info("Background cache processing started")
         let startTime = Date()
 
-        // Set expiration handler
-        task.expirationHandler = {
-            Logger.backgroundTask.warning("Background cache processing expired")
-            task.setTaskCompleted(success: false)
-        }
-
-        do {
+        // Use a cancellable task so the expiration handler can stop work
+        let processingTask = Task {
             let documents = try await archiveStore.getDocuments()
-            let newCachesCreated = await contentExtractorStore.processUntaggedDocumentsInBackground(
+            return await contentExtractorStore.processUntaggedDocumentsInBackground(
                 documents,
                 textAnalyser.getTextFrom,
                 customPrompt
             )
+        }
 
+        // Set expiration handler to cancel the work instead of completing the task directly
+        task.expirationHandler = {
+            Logger.backgroundTask.warning("Background cache processing expired")
+            processingTask.cancel()
+        }
+
+        do {
+            let newCachesCreated = try await processingTask.value
             let processingDuration = Date().timeIntervalSince(startTime)
 
             if shouldNotify {
@@ -101,8 +105,7 @@ public actor BackgroundTaskManager: Log {
         } catch {
             Logger.backgroundTask.error("Background cache processing failed: \(error)")
 
-            if shouldNotify {
-                // Show local notification on failure
+            if shouldNotify && !Task.isCancelled {
                 await UNUserNotificationCenter.current().showLocalNotification(
                     title: "Processing Failed",
                     body: "Apple Intelligence cache processing failed: \(error.localizedDescription)"

--- a/ArchiverLib/Sources/ArchiverStore/ArchiveStore.swift
+++ b/ArchiverLib/Sources/ArchiverStore/ArchiveStore.swift
@@ -72,7 +72,10 @@ public actor ArchiveStore: Log {
     func update(archiveFolder: URL, untaggedFolders: [URL]) async {
         isLoadingStream.send(true)
 
-        // remove all current file providers to prevent watching changes while moving folders
+        // stop all current file providers to prevent watching changes while moving folders
+        for provider in providers {
+            await provider.stop()
+        }
         providers = []
         folderObservationTasks.forEach { $0.cancel() }
         folderObservationTasks = []

--- a/ArchiverLib/Sources/ArchiverStore/FolderAccess/FolderProvider.swift
+++ b/ArchiverLib/Sources/ArchiverStore/FolderAccess/FolderProvider.swift
@@ -34,6 +34,8 @@ protocol FolderProvider: AnyObject, Log, Sendable {
 
     init(baseUrl: URL) throws
 
+    func stop()
+
     func save(data: Data, at: URL) throws
     func startDownload(of: URL) throws
     func fetch(url: URL) throws -> Data

--- a/ArchiverLib/Sources/ArchiverStore/FolderAccess/demo/DemoFolderProvider.swift
+++ b/ArchiverLib/Sources/ArchiverStore/FolderAccess/demo/DemoFolderProvider.swift
@@ -50,6 +50,8 @@ final class DemoFolderProvider: FolderProvider, Log {
         log.debug("delete(url: URL) throws")
     }
 
+    func stop() {}
+
     func rename(from: URL, to: URL) throws {
         log.debug("rename(from: URL, to: URL) throws")
     }

--- a/ArchiverLib/Sources/ArchiverStore/FolderAccess/iCloud/ICloudFolderProvider.swift
+++ b/ArchiverLib/Sources/ArchiverStore/FolderAccess/iCloud/ICloudFolderProvider.swift
@@ -20,6 +20,7 @@ final class ICloudFolderProvider: FolderProvider {
 
     private var currentDocuments: [Int: DocumentInformation] = [:]
     private var lastDocuments: [DocumentInformation]?
+    private var observationTask: Task<Void, Never>?
 
     init(baseUrl: URL) throws {
         self.baseUrl = baseUrl
@@ -59,10 +60,16 @@ final class ICloudFolderProvider: FolderProvider {
          */
         metadataQuery.operationQueue = .main
 
-        Task(priority: .utility) {
+        observationTask = Task(priority: .utility) { [weak self] in
+            guard let self else { return }
+
+            self.metadataQuery.start()
+            self.log.debug("Starting the documents query.")
+
             await withTaskGroup(of: Void.self) { group in
-                group.addTask {
+                group.addTask { [weak self] in
                     for await _ in NotificationCenter.default.notifications(named: .NSMetadataQueryDidFinishGathering) {
+                        guard let self else { return }
                         Self.log.debug("Documents query finished initial fetch.")
 
                         let details = await self.getFileChangeDetails()
@@ -75,8 +82,9 @@ final class ICloudFolderProvider: FolderProvider {
                     }
                 }
 
-                group.addTask {
+                group.addTask { [weak self] in
                     for await notification in NotificationCenter.default.notifications(named: .NSMetadataQueryDidUpdate) {
+                        guard let self else { return }
                         let addedMetadataItems = (notification.userInfo?[NSMetadataQueryUpdateAddedItemsKey] as? [NSMetadataItem]) ?? []
                         let updatedMetadataItems = (notification.userInfo?[NSMetadataQueryUpdateChangedItemsKey] as? [NSMetadataItem]) ?? []
                         let removedMetadataItems = (notification.userInfo?[NSMetadataQueryUpdateRemovedItemsKey] as? [NSMetadataItem]) ?? []
@@ -92,15 +100,19 @@ final class ICloudFolderProvider: FolderProvider {
                         await self.sendDocuments(added: added, updated: updated, removed: removed)
                     }
                 }
-
-                metadataQuery.start()
-                log.debug("Starting the documents query.")
             }
         }
     }
 
     deinit {
         Self.log.debug("deinit ICloudFolderProvider")
+        observationTask?.cancel()
+        metadataQuery.stop()
+    }
+
+    func stop() {
+        observationTask?.cancel()
+        observationTask = nil
         metadataQuery.stop()
     }
 

--- a/ArchiverLib/Sources/ArchiverStore/FolderAccess/local/DirectoryWatcher/DirectoryDeepWatcher.swift
+++ b/ArchiverLib/Sources/ArchiverStore/FolderAccess/local/DirectoryWatcher/DirectoryDeepWatcher.swift
@@ -31,11 +31,8 @@ actor DirectoryDeepWatcher: Log {
     }
 
     deinit {
-        Task { [sources] in
-            for (_, source) in sources {
-                source.1.cancel()
-                await source.0.cancel()
-            }
+        for (_, source) in sources {
+            source.1.cancel()
         }
         sources.removeAll()
     }

--- a/ArchiverLib/Sources/ArchiverStore/FolderAccess/local/LocalFolderProvider.swift
+++ b/ArchiverLib/Sources/ArchiverStore/FolderAccess/local/LocalFolderProvider.swift
@@ -19,6 +19,7 @@ final class LocalFolderProvider: FolderProvider {
     private let watcher: DirectoryDeepWatcher
     private let fileManager = FileManager.default
     private let fileProperties: [URLResourceKey] = [.ubiquitousItemDownloadingStatusKey, .ubiquitousItemIsDownloadingKey, .fileSizeKey, .localizedNameKey]
+    private var observationTask: Task<Void, Never>?
 
     required init(baseUrl: URL) throws {
         self.baseUrl = baseUrl
@@ -33,13 +34,15 @@ final class LocalFolderProvider: FolderProvider {
 
         self.watcher = try DirectoryDeepWatcher(at: baseUrl)
 
-        Task(priority: .background) {
+        observationTask = Task(priority: .background) { [weak self] in
+            guard let self else { return }
+
             // build initial changes
             let documents = await self.createDocuments()
             self.currentDocumentsStreamContinuation.yield(documents)
 
             // listen to changes in folder
-            // we debouce this because the `DirectoryDeepWatcher` currently triggers too often
+            // we debounce this because the `DirectoryDeepWatcher` currently triggers too often
             for await _ in self.watcher.changedUrlStream.debounce(for: .milliseconds(500)) {
                 let documents = await self.createDocuments()
                 self.currentDocumentsStreamContinuation.yield(documents)
@@ -48,8 +51,14 @@ final class LocalFolderProvider: FolderProvider {
     }
 
     deinit {
+        observationTask?.cancel()
         guard didAccessSecurityScope else { return }
         baseUrl.stopAccessingSecurityScopedResource()
+    }
+
+    func stop() {
+        observationTask?.cancel()
+        observationTask = nil
     }
 
     // MARK: - API


### PR DESCRIPTION
## Changes

- Fix retain cycles in `ICloudFolderProvider` and `LocalFolderProvider` — unstructured tasks in `init` captured `self` strongly, preventing deallocation when `ArchiveStore.update()` replaced providers
- Add `stop()` to `FolderProvider` protocol, called from `ArchiveStore.update()` before replacing providers
- Fix `withCheckedContinuation` hang in `DocumentProcessingService.handle(_:)` — `onComplete` was never called when `PDFProcessingOperation` failed
- Fix `BackgroundTaskManager` expiration handler race — both expiration handler and main body could call `setTaskCompleted`; now uses cancellable task pattern
- Move `Task.detached` from `AppView.init` to `.task` modifier to prevent duplicate work on SwiftUI view re-creation
- Simplify `DirectoryDeepWatcher.deinit` to synchronous task cancellation