### PR TITLE
Clean up Swift concurrency patterns

### DIFF
--- a/ArchiverLib/Sources/ArchiverDocumentProcessing/DocumentProcessingService.swift
+++ b/ArchiverLib/Sources/ArchiverDocumentProcessing/DocumentProcessingService.swift
@@ -40,10 +40,8 @@ public final class DocumentProcessingService: Sendable {
 
         return await withCheckedContinuation { continuation in
             let operation = PDFProcessingOperation(of: .images(images), destinationFolder: destinationFolder, onComplete: { documentUrl in
-                Task {
-                    self.lastProcessedDocumentUrl = documentUrl
-                    continuation.resume(returning: documentUrl)
-                }
+                self.lastProcessedDocumentUrl = documentUrl
+                continuation.resume(returning: documentUrl)
             })
             backgroundProcessing.queue(operation)
         }
@@ -55,9 +53,7 @@ public final class DocumentProcessingService: Sendable {
             return
         }
         let operation = PDFProcessingOperation(of: .pdf(pdfData: pdfData, url: url), destinationFolder: destinationFolder, onComplete: { documentUrl in
-            Task {
-                self.lastProcessedDocumentUrl = documentUrl ?? self.lastProcessedDocumentUrl
-            }
+            self.lastProcessedDocumentUrl = documentUrl ?? self.lastProcessedDocumentUrl
         })
         backgroundProcessing.queue(operation)
     }

--- a/ArchiverLib/Sources/ArchiverFeatures/AppFeature/Import/DocumentCameraView.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/AppFeature/Import/DocumentCameraView.swift
@@ -46,12 +46,13 @@ struct DocumentCameraView: UIViewControllerRepresentable, Log {
         func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
             self.isShown.wrappedValue = false
 
-            DispatchQueue.global(qos: .userInitiated).async {
+            let imageHandler = self.imageHandler
+            Task.detached(priority: .userInitiated) {
                 var images = [PlatformImage]()
                 for index in 0..<scan.pageCount {
                     images.append(scan.imageOfPage(at: index))
                 }
-                self.imageHandler(images)
+                imageHandler(images)
             }
         }
 

--- a/ArchiverLib/Sources/ArchiverStore/FolderAccess/local/DirectoryWatcher/DirectoryDeepWatcher.swift
+++ b/ArchiverLib/Sources/ArchiverStore/FolderAccess/local/DirectoryWatcher/DirectoryDeepWatcher.swift
@@ -53,8 +53,12 @@ actor DirectoryDeepWatcher: Log {
             // create source for the parent directory
             try createAndAddSource(from: baseUrl)
 
-            // Actor isolation serializes access, so no separate queue synchronization is needed.
-            try startWatching(contentsOf: baseUrl)
+            // We have to startWatching an the queue, because during the initial creating of all sources
+            // one folder (e.g. the first) might be changed, which triggers the event handler on the queue.
+            // By syncing these calls on a serial queue, they will be processed one after another.
+            try queue.sync {
+                try startWatching(contentsOf: baseUrl)
+            }
         } catch {
             log.error("Failed to create DirectoryDeepWatcher", metadata: ["error": "\(error)"])
             throw error

--- a/ArchiverLib/Sources/ArchiverStore/FolderAccess/local/DirectoryWatcher/DirectoryDeepWatcher.swift
+++ b/ArchiverLib/Sources/ArchiverStore/FolderAccess/local/DirectoryWatcher/DirectoryDeepWatcher.swift
@@ -53,12 +53,8 @@ actor DirectoryDeepWatcher: Log {
             // create source for the parent directory
             try createAndAddSource(from: baseUrl)
 
-            // We have to startWatching an the queue, because during the initial creating of all sources
-            // one folder (e.g. the first) might be changed, which triggers the event handler on the queue.
-            // By syncing these calls on a serial queue, they will be processed one after another.
-            try queue.sync {
-                try startWatching(contentsOf: baseUrl)
-            }
+            // Actor isolation serializes access, so no separate queue synchronization is needed.
+            try startWatching(contentsOf: baseUrl)
         } catch {
             log.error("Failed to create DirectoryDeepWatcher", metadata: ["error": "\(error)"])
             throw error


### PR DESCRIPTION
## Changes
- Remove unnecessary `Task {}` wrappers in `DocumentProcessingService` onComplete callbacks — the closure is already `@StorageActor`-isolated
- Remove `queue.sync` in `DirectoryDeepWatcher` — actor isolation already serializes access
- Replace `DispatchQueue.global` with `Task.detached` in `DocumentCameraView` for idiomatic Swift concurrency