### PR TITLE
Fix Swift Testing review issues

### DIFF
--- a/ArchiverLib/Tests/ArchiverDocumentProcessingTests/PDFProcessingTests.swift
+++ b/ArchiverLib/Tests/ArchiverDocumentProcessingTests/PDFProcessingTests.swift
@@ -59,7 +59,7 @@ final class PDFProcessingTests {
     // swiftlint:enable identifier_name
 
     @Test
-    func testPDFInput() async throws {
+    func pdfInput() async throws {
         let exampleUrl = Self.tempFolder.appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("pdf")
         try FileManager.default.copyItem(at: Bundle.longTextPDFUrl, to: exampleUrl)
@@ -85,7 +85,7 @@ final class PDFProcessingTests {
     }
 
     @Test(.disabled("Currently not working"))
-    func testPNGInput() async throws {
+    func pngInput() async throws {
         let image = try #require(PlatformImage(contentsOf: Bundle.billPNGUrl))
 
         var documentUrl: URL?
@@ -156,7 +156,7 @@ final class PDFProcessingTests {
     }
 
     @Test(.disabled("Currently not working"))
-    func testJPGInput() async throws {
+    func jpgInput() async throws {
         let image = try #require(PlatformImage(contentsOf: Bundle.billJPGGUrl))
 
         var documentUrl: URL?
@@ -226,7 +226,7 @@ final class PDFProcessingTests {
     }
 
     @Test(.disabled("Currently not working"))
-    func testJPGMultiplePages() async throws {
+    func jpgMultiplePages() async throws {
         let image = try #require(PlatformImage(contentsOf: Bundle.billJPGGUrl))
 
         var documentUrl: URL?

--- a/ArchiverLib/Tests/ArchiverFeaturesTests/SettingsTests.swift
+++ b/ArchiverLib/Tests/ArchiverFeaturesTests/SettingsTests.swift
@@ -43,8 +43,7 @@ struct SettingsTests {
     func defaultStorageType() async throws {
         let state = Settings.State()
 
-        // Storage type may be nil initially or have a value
-        #expect(state.selectedArchiveType == nil || state.selectedArchiveType != nil)
+        #expect(state.selectedArchiveType == nil)
     }
 
     // MARK: - Navigation Tests
@@ -134,8 +133,7 @@ struct SettingsTests {
     func premiumSectionInitialized() async throws {
         let state = Settings.State()
 
-        // Premium section is always initialized (not optional)
-        #expect(state.premiumSection.premiumStatus == .loading || state.premiumSection.premiumStatus == .active || state.premiumSection.premiumStatus == .inactive)
+        #expect(state.premiumSection.premiumStatus == .loading)
     }
 
     @Test
@@ -216,8 +214,7 @@ struct SettingsTests {
     func observedFolderURL() async throws {
         let state = Settings.State()
 
-        // Observed folder may be nil initially
-        #expect(state.observedFolderURL == nil || state.observedFolderURL != nil)
+        #expect(state.observedFolderURL == nil)
     }
 
     @Test

--- a/ArchiverLib/Tests/ArchiverFeaturesTests/SettingsTests.swift
+++ b/ArchiverLib/Tests/ArchiverFeaturesTests/SettingsTests.swift
@@ -133,7 +133,7 @@ struct SettingsTests {
     func premiumSectionInitialized() async throws {
         let state = Settings.State()
 
-        #expect(state.premiumSection.premiumStatus == .loading)
+        #expect(state.premiumSection.premiumStatus == .inactive)
     }
 
     @Test

--- a/ArchiverLib/Tests/ArchiverFeaturesTests/UntaggedDocumentListTests.swift
+++ b/ArchiverLib/Tests/ArchiverFeaturesTests/UntaggedDocumentListTests.swift
@@ -64,7 +64,7 @@ struct UntaggedDocumentListTests {
         #expect(state.untaggedDocuments.count == 2)
         #expect(state.untaggedDocuments.contains(where: { $0.id == untaggedDoc1.id }))
         #expect(state.untaggedDocuments.contains(where: { $0.id == untaggedDoc2.id }))
-        #expect(!state.untaggedDocuments.contains(where: { $0.id == taggedDoc.id }))
+        #expect(state.untaggedDocuments.contains(where: { $0.id == taggedDoc.id }) == false)
     }
 
     @Test
@@ -101,8 +101,7 @@ struct UntaggedDocumentListTests {
     @Test
     func premiumStatusActive() async throws {
         let state = UntaggedDocumentList.State()
-        // Premium status is shared and defaults to .loading
-        #expect(state.premiumStatus == .loading || state.premiumStatus == .active || state.premiumStatus == .inactive)
+        #expect(state.premiumStatus == .loading)
     }
 
     // MARK: - Document Details Tests

--- a/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/ArrayUrlTests.swift
+++ b/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/ArrayUrlTests.swift
@@ -13,7 +13,7 @@ import Testing
 @MainActor
 struct ArrayURLTests {
     @Test
-    func testParents() async throws {
+    func uniqueParents() async throws {
         // swiftlint:disable force_unwrapping
         let url1 = URL(string: "/test/folder1/archive/untagged")!
         let url2 = URL(string: "/test/folder1/archive")!

--- a/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/DateParserTests.swift
+++ b/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/DateParserTests.swift
@@ -26,7 +26,7 @@ struct DateParserTests {
     }
 
     @Test
-    func testParsingValidDate() async throws {
+    func parsingValidDate() async throws {
 
         // setup the raw string
         let hiddenDate = "20050201"
@@ -104,7 +104,7 @@ struct DateParserTests {
     }
 
     @Test
-    func testParsingAmbiguousDate() async throws {
+    func parsingAmbiguousDate() async throws {
 
         // setup the raw string - different expectations based on locale
         let rawStringMapping: [String: Date?]
@@ -136,7 +136,7 @@ struct DateParserTests {
     }
 
     @Test
-    func testParsingInvalidDates() async {
+    func parsingInvalidDates() async {
 
         // setup the raw string
         let rawStrings = ["2015-35-12",
@@ -155,7 +155,7 @@ struct DateParserTests {
     }
 
     @Test
-    func testPerformanceExample() async throws {
+    func parsingDateFromLongText() async throws {
 
         // setup the long string
         let hiddenDate = "20050201"
@@ -183,7 +183,7 @@ struct DateParserTests {
     }
 
     @Test
-    func testParsingDateWithUnderscores() async throws {
+    func parsingDateWithUnderscores() async throws {
 
         // setup - test replacing underscores with dashes
         let input = "1990_02_11"

--- a/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/DeepDirectoryWatcherTests.swift
+++ b/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/DeepDirectoryWatcherTests.swift
@@ -7,7 +7,6 @@ import Testing
 ///
 /// **Attention:** These tests are skipped, since the current implementation of the `DirectoryDeepWatcher` will trigger too oftern.
 /// We handle this by debouncing these calls.
-@Suite(.serialized)
 @MainActor
 final class DeepDirectoryWatcherTests {
 
@@ -43,7 +42,7 @@ final class DeepDirectoryWatcherTests {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
-    @Test(.enabled(if: false), .timeLimit(.minutes(1)))
+    @Test(.disabled("DirectoryDeepWatcher triggers too often; handled by debouncing"), .timeLimit(.minutes(1)))
     func removeSingleFolder() async throws {
         guard let tempDir else {
             Issue.record("Engine could not find temp folder")
@@ -72,7 +71,7 @@ final class DeepDirectoryWatcherTests {
         watcher = nil
     }
 
-    @Test(.enabled(if: false))
+    @Test(.disabled("DirectoryDeepWatcher triggers too often; handled by debouncing"))
     func removeMultipleFolders() async throws {
         guard let tempDir else {
             Issue.record("Engine could not find temp folder")
@@ -103,8 +102,8 @@ final class DeepDirectoryWatcherTests {
         watcher = nil
     }
 
-    @Test(.enabled(if: false))
-    func testFileRemove() async throws {
+    @Test(.disabled("DirectoryDeepWatcher triggers too often; handled by debouncing"))
+    func fileRemove() async throws {
         guard let tempDir else {
             Issue.record("Engine could not find temp folder")
             return
@@ -131,8 +130,8 @@ final class DeepDirectoryWatcherTests {
         watcher = nil
     }
 
-    @Test(.enabled(if: false))
-    func testFileAdded() async throws {
+    @Test(.disabled("DirectoryDeepWatcher triggers too often; handled by debouncing"))
+    func fileAdded() async throws {
         guard let tempDir else {
             Issue.record("Engine could not find temp folder")
             return

--- a/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/DocumentTests.swift
+++ b/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/DocumentTests.swift
@@ -27,7 +27,7 @@ struct DocumentTests {
     // MARK: - Test await Document.parseFilename
 
     @Test
-    func testFilenameParsing1() async {
+    func filenameParsing1() async {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/2010-05-12--example-description__tag1_tag2_tag4.pdf")
@@ -42,7 +42,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testFilenameParsing2() async {
+    func filenameParsing2() async {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/2010-05-12__tag1_tag2_tag4.pdf")
@@ -57,7 +57,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testFilenameParsing3() async {
+    func filenameParsing3() async {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/scan 1.pdf")
@@ -72,7 +72,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testFilenameParsing4() async {
+    func filenameParsing4() async {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/2019-09-02--gfwob abrechnung für 2018__hausgeldabrechung_steuer_wohnung.pdf")
@@ -89,7 +89,7 @@ struct DocumentTests {
     // MARK: - Test Document.getRenamingPath
 
     @Test
-    func testDocumentRenaming() async throws {
+    func documentRenaming() async throws {
 
         // setup
         let date = try #require(dateFormatter.date(from: "2010-05-12"))
@@ -102,7 +102,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentRenamingWithSpaceInDescriptionSlugify() async throws {
+    func documentRenamingWithSpaceInDescriptionSlugify() async throws {
 
         // setup
         let date = try #require(dateFormatter.date(from: "2010-05-12"))
@@ -114,7 +114,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentRenamingWithFullFilename() async throws {
+    func documentRenamingWithFullFilename() async throws {
 
         // setup
         let date = try #require(dateFormatter.date(from: "2010-05-12"))
@@ -127,7 +127,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentRenamingWithNoTags() async {
+    func documentRenamingWithNoTags() async {
 
         // setup
         let filename = "scan1.pdf"
@@ -142,7 +142,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentRenamingWithNoSpecification() async {
+    func documentRenamingWithNoSpecification() async {
 
         // setup
         let filename = "scan1__tag1_tag2.pdf"
@@ -159,7 +159,7 @@ struct DocumentTests {
     // MARK: - Test the whole workflow
 
     @Test
-    func testDocumentNameParsing() async throws {
+    func documentNameParsing() async throws {
 
         // setup some of the testing variables
         let path = URL(fileURLWithPath: "~/Downloads/2010-05-12--example-description__tag1_tag2_tag4.pdf")
@@ -178,7 +178,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentDateParsingFormat0() async throws {
+    func documentDateParsingFormat0() async throws {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/2010-05-12--example-filename__test.pdf")
@@ -196,7 +196,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentDateParsingFormat1() async throws {
+    func documentDateParsingFormat1() async throws {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/2010-05-12 example filename.pdf")
@@ -214,7 +214,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentDateParsingFormat2() async throws {
+    func documentDateParsingFormat2() async throws {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/2010_05_12 example filename.pdf")
@@ -231,7 +231,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentDateParsingFormat3() async throws {
+    func documentDateParsingFormat3() async throws {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/20100512 example filename.pdf")
@@ -248,7 +248,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentDateParsingFormat4() async throws {
+    func documentDateParsingFormat4() async throws {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/2010_05_12__15_17.pdf")
@@ -265,7 +265,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentDateParsingScanSnapFormat() async {
+    func documentDateParsingScanSnapFormat() async {
 
         // setup
         let path = URL(fileURLWithPath: "~/Downloads/2010_05_12_15_17.pdf")
@@ -280,7 +280,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testPlaceholder() async throws {
+    func placeholder() async throws {
 
         // setup
         let date = try #require(dateFormatter.date(from: "2018-05-12"))
@@ -299,7 +299,7 @@ struct DocumentTests {
     }
 
     @Test
-    func testDocumentRenamingPath() async throws {
+    func documentRenamingPath() async throws {
 
         // setup
         let date = try #require(dateFormatter.date(from: "2010-05-12"))

--- a/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/PathManagerTests.swift
+++ b/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/PathManagerTests.swift
@@ -27,7 +27,7 @@ final class PathManagerTests {
 
     #if os(macOS)
     @Test(.disabled("Currently not working"))
-    func testArchiveChangeMacOS() throws {
+    func archiveChangeMacOS() throws {
         let currentArchiveFolder = Self.tempFolder.appendingPathComponent("CurrentArchive")
         try FileManager.default.createDirectory(at: currentArchiveFolder, withIntermediateDirectories: true, attributes: nil)
 //        try PathManager.shared.setArchiveUrl(with: .local(currentArchiveFolder))
@@ -56,14 +56,14 @@ final class PathManagerTests {
         #expect(urls.contains(where: { $0.lastPathComponent == "2019" }))
         #expect(urls.contains(where: { $0.lastPathComponent == "2018" }))
 
-        #expect(false == urls.contains(where: { $0.lastPathComponent == "inbox" }))
-        #expect(false == urls.contains(where: { $0.lastPathComponent == "test" }))
+        #expect(urls.contains(where: { $0.lastPathComponent == "inbox" }) == false)
+        #expect(urls.contains(where: { $0.lastPathComponent == "test" }) == false)
     }
     #endif
 
     #if !os(macOS)
     @Test
-    func testPDFInput() throws {
+    func pdfInput() throws {
         let currentArchiveFolder = Self.tempFolder.appendingPathComponent("CurrentArchive")
         try FileManager.default.createDirectory(at: currentArchiveFolder, withIntermediateDirectories: true, attributes: nil)
 
@@ -96,8 +96,8 @@ final class PathManagerTests {
         #expect(urls.contains(where: { $0.lastPathComponent == "2019" }))
         #expect(urls.contains(where: { $0.lastPathComponent == "2018" }))
 
-        #expect(!urls.contains(where: { $0.lastPathComponent == "inbox" }))
-        #expect(!urls.contains(where: { $0.lastPathComponent == "test" }))
+        #expect(urls.contains(where: { $0.lastPathComponent == "inbox" }) == false)
+        #expect(urls.contains(where: { $0.lastPathComponent == "test" }) == false)
     }
     #endif
 }

--- a/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/StringTests.swift
+++ b/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/StringTests.swift
@@ -11,38 +11,29 @@ import Testing
 @MainActor
 struct StringExtensionTests {
 
-    @Test
-    func testSlugify() {
-
-        // setup
-        let stringMapping = ["Ä": "Ae",
-                             "Ö": "Oe",
-                             "Ü": "Ue",
-                             "ä": "ae",
-                             "ö": "oe",
-                             "ü": "ue",
-                             "ß": "ss",
-                             "é": "e",
-                             "2017": "2017",
-                             "AbC2017": "AbC2017",
-                             "AbC, 2017 Def": "AbC-2017-Def",
-                             "привет": "",
-                             "Liebe Grüße aus Ovelgönne": "Liebe-Gruesse-aus-Ovelgoenne",
-                             "Hello, ___ this !! is a TEst!?!": "Hello-this-is-a-TEst",
-                             "Hello ---- again!!": "Hello-again"]
-
-        for (raw, slugified) in stringMapping {
-
-            // calculate
-            let newSlugifiedString = raw.slugified()
-
-            // assert
-            #expect(newSlugifiedString == slugified)
-        }
+    @Test(arguments: [
+        ("Ä", "Ae"),
+        ("Ö", "Oe"),
+        ("Ü", "Ue"),
+        ("ä", "ae"),
+        ("ö", "oe"),
+        ("ü", "ue"),
+        ("ß", "ss"),
+        ("é", "e"),
+        ("2017", "2017"),
+        ("AbC2017", "AbC2017"),
+        ("AbC, 2017 Def", "AbC-2017-Def"),
+        ("привет", ""),
+        ("Liebe Grüße aus Ovelgönne", "Liebe-Gruesse-aus-Ovelgoenne"),
+        ("Hello, ___ this !! is a TEst!?!", "Hello-this-is-a-TEst"),
+        ("Hello ---- again!!", "Hello-again"),
+    ])
+    func slugify(input: String, expected: String) {
+        #expect(input.slugified() == expected)
     }
 
     @Test
-    func testCapitalizingFirstLetter() {
+    func capitalizingFirstLetter() {
 
         // setup
         let testString = "test"
@@ -55,7 +46,7 @@ struct StringExtensionTests {
     }
 
     @Test
-    func testCapitalizingFirstLetter2() {
+    func capitalizingFirstLetterMultipleWords() {
 
         // setup
         let testString = "this is another test"
@@ -68,7 +59,7 @@ struct StringExtensionTests {
     }
 
     @Test
-    func testReplacingMethod() {
+    func replacingMethod() {
 
         // setup
         let testString = "Äpfel und Öl"
@@ -82,7 +73,7 @@ struct StringExtensionTests {
     }
 
     @Test
-    func testReplacingWithRegex() {
+    func replacingWithRegex() {
 
         // setup
         let testString = "test--multiple---dashes"
@@ -95,7 +86,7 @@ struct StringExtensionTests {
     }
 
     @Test
-    func testReplacingSpecialCharacters() {
+    func replacingSpecialCharacters() {
 
         // setup
         let testString = "ß test ä ö ü Ä Ö Ü"

--- a/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/TagParserTests.swift
+++ b/ArchiverLib/Tests/ArchiverStoreTests/ArchiveBackendTests/TagParserTests.swift
@@ -12,7 +12,7 @@ import Testing
 @MainActor
 struct TagParserTests {
     @Test
-    func testParsingValidTags() async throws {
+    func parsingValidTags() async throws {
 
         // setup the raw string
         let rawStringMapping: [String: Set<String>] = [
@@ -31,7 +31,7 @@ struct TagParserTests {
     }
 
     @Test
-    func testParsingInvalidTags() async {
+    func parsingInvalidTags() async {
 
         // setup the raw string
         let rawStringMapping: [String: Set<String>] = [


### PR DESCRIPTION
## Changes
- Remove ineffective `@Suite(.serialized)` from `DeepDirectoryWatcherTests` (only applies to parameterized tests)
- Replace `.enabled(if: false)` with `.disabled()` including reason strings
- Fix tautological assertions in `SettingsTests` and `UntaggedDocumentListTests` that always pass
- Replace `!` negation in `#expect` with `== false` for proper Swift Testing macro diagnostics
- Fix reversed `#expect(false == ...)` comparisons in `PathManagerTests`
- Convert `StringTests.testSlugify` loop to parameterized test for per-case pass/fail
- Remove unnecessary `test` prefix from ~20 method names

## Test plan
- [x] `swift build --build-tests` passes
- [ ] `swift test` passes