### PR TITLE
Fix remaining code review findings

### DIFF
--- a/ArchiverLib/Sources/ArchiverDocumentProcessing/PDFProcessing.swift
+++ b/ArchiverLib/Sources/ArchiverDocumentProcessing/PDFProcessing.swift
@@ -144,7 +144,10 @@ final class PDFProcessingOperation: AsyncOperation {
     private func createPdf(from images: [PlatformImage]) async throws -> PDFDocument {
         var textObservations = [TextObservation]()
         for image in images {
-            guard let cgImage = image.cgImage else { fatalError("Could not get cgImage") }
+            guard let cgImage = image.cgImage else {
+                Logger.documentProcessing.errorAndAssert("Could not get cgImage - skipping image")
+                continue
+            }
             let requestHandler = VNImageRequestHandler(cgImage: cgImage, options: [:])
             var detectTextRectangleObservations = [VNTextObservation]()
             let textBoxRequests = VNDetectTextRectanglesRequest { (request, error) in
@@ -187,6 +190,9 @@ final class PDFProcessingOperation: AsyncOperation {
                                 thisObservation.append(candidate.string)
                             }
                             let fullObservation = thisObservation.joined(separator: " ")
+
+                            // skip empty observations - they would produce a NaN font expansion in createCleared
+                            guard !fullObservation.isEmpty else { return }
                             textObservationResults.append(TextObservationResult(rect: textBox, text: fullObservation))
                         }
                     }
@@ -253,7 +259,10 @@ final class PDFProcessingOperation: AsyncOperation {
 
             // extract pdf from context
             guard let document = PDFDocument(data: data as Data),
-                  let page = document.page(at: 0) else { fatalError("Could not generate PDF document.") }
+                  let page = document.page(at: 0) else {
+                Logger.documentProcessing.errorAndAssert("Could not generate PDF document - skipping page")
+                continue
+            }
             pages.append(page)
         }
 

--- a/ArchiverLib/Sources/ArchiverFeatures/AppFeature/AppFeature.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/AppFeature/AppFeature.swift
@@ -229,8 +229,8 @@ struct AppFeature {
 
                             #if os(iOS)
                             if #available(iOS 26, *) {
-                                // trigger task scheduling
-                                BackgroundTaskManager.registerTaskHandlers()
+                                // trigger task scheduling - the handler itself is registered
+                                // in the app initializer, as required by BGTaskScheduler
                                 BackgroundTaskManager.scheduleCacheProcessing()
                             }
                             #endif

--- a/ArchiverLib/Sources/ArchiverFeatures/ArchiveList/ArchiveList.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/ArchiveList/ArchiveList.swift
@@ -50,7 +50,11 @@ struct ArchiveList {
         var isSearching = false
         var searchText = ""
         var searchTokens: [SearchToken] = []
-        var searchSuggestedTokens: [SearchToken] = [.year(2025), .year(2024)]
+        // fallback until real suggestions are derived from the documents in AppFeature
+        var searchSuggestedTokens: [SearchToken] = {
+            let currentYear = Calendar.current.component(.year, from: Date())
+            return [.year(currentYear), .year(currentYear - 1)]
+        }()
         @Presents var documentDetails: DocumentDetails.State?
 
         private func getFilteredDocument() -> IdentifiedArrayOf<Document> {
@@ -111,7 +115,11 @@ struct ArchiveList {
                 var searchText = state.searchText
                 if searchText.popLast() == " " {
                     let newSearchText = searchText.slugified(withSeparator: "").lowercased()
-                    state.searchTokens.append(.text(newSearchText))
+
+                    // an empty token would filter out all documents
+                    if !newSearchText.isEmpty {
+                        state.searchTokens.append(.text(newSearchText))
+                    }
                     state.searchText = ""
                 }
                 return .none

--- a/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/BackgroundTaskManager.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/BackgroundTaskManager.swift
@@ -105,7 +105,7 @@ public actor BackgroundTaskManager: Log {
         } catch {
             Logger.backgroundTask.error("Background cache processing failed: \(error)")
 
-            if shouldNotify && !Task.isCancelled {
+            if shouldNotify && !processingTask.isCancelled {
                 await UNUserNotificationCenter.current().showLocalNotification(
                     title: "Processing Failed",
                     body: "Apple Intelligence cache processing failed: \(error.localizedDescription)"

--- a/ArchiverLib/Sources/ArchiverFeatures/Settings/Settings.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/Settings/Settings.swift
@@ -160,18 +160,18 @@ struct Settings {
                 state.isShowingMailSheet = true
                 return .none
                 #else
-                // swiftlint:disable:next force_unwrapping
-                let url = URL(string: "mailto:\(Constants.mailRecipient)?subject=\(Constants.mailSubject)")!
-
-                #if DEBUG
-                assertionFailure("TODO: this is currently not working on macOS")
-                return .run { [url] _ in
-                    await openURL(url)
+                // build the mailto URL via URLComponents to get proper percent encoding
+                var components = URLComponents()
+                components.scheme = "mailto"
+                components.path = Constants.mailRecipient
+                components.queryItems = [URLQueryItem(name: "subject", value: Constants.mailSubject)]
+                guard let url = components.url else {
+                    Logger.settings.errorAndAssert("Failed to create mailto url")
+                    return .none
                 }
-                #else
+
                 NSWorkspace.shared.open(url)
                 return .none
-                #endif
                 #endif
 
             case .onImprintTapped:

--- a/ArchiverLib/Sources/ArchiverStore/ArchiveStore.swift
+++ b/ArchiverLib/Sources/ArchiverStore/ArchiveStore.swift
@@ -68,7 +68,7 @@ public actor ArchiveStore: Log {
     }
 
     public func getUntaggedUrl() async throws -> URL {
-        try await PathManager.shared.getArchiveUrl().appending(component: "untagged")
+        try await PathManager.shared.getUntaggedUrl()
     }
 
     func update(archiveFolder: URL, untaggedFolders: [URL]) async {

--- a/ArchiverLib/Sources/ArchiverStore/FolderAccess/PathManager.swift
+++ b/ArchiverLib/Sources/ArchiverStore/FolderAccess/PathManager.swift
@@ -98,6 +98,9 @@ final class PathManager: Log {
             }
         }
 
+        // Save the new path even if some folders could not be moved: the user chose the
+        // new location and should continue working there - the error below only informs
+        // about the documents that were left behind at the old location.
         self.$archivePathType.withLock { $0 = type }
 
         if let moveError = moveError {

--- a/ArchiverLib/Sources/ArchiverStore/FolderAccess/iCloud/ICloudFolderProvider.swift
+++ b/ArchiverLib/Sources/ArchiverStore/FolderAccess/iCloud/ICloudFolderProvider.swift
@@ -118,12 +118,9 @@ final class ICloudFolderProvider: FolderProvider {
             currentDocuments[id] = change
         }
         for change in removed {
-            guard let id = change.url.uniqueId() else {
-                assertionFailure("Failed to get uniqueId for \(change.url)")
-                currentDocuments = currentDocuments.filter { $0.value.url != change.url }
-                continue
-            }
-            currentDocuments[id] = nil
+            // match removed files by URL - reading the uniqueId (a resource value)
+            // of an already deleted file would fail
+            currentDocuments = currentDocuments.filter { $0.value.url != change.url }
         }
         let documents = Array(currentDocuments.values)
         guard lastDocuments?.sorted() != documents.sorted() else { return }
@@ -231,8 +228,9 @@ extension NSMetadataItem: nonisolated Log {
                 documentStatus = minValue
             }
         default:
+            // do not crash on future/unknown status values - just skip this item
             log.criticalAndAssert("Unkown download status.", metadata: ["status": "\(downloadingStatus)"])
-            preconditionFailure("The downloading status '\(downloadingStatus)' was not handled correctly!")
+            return nil
         }
 
         return DocumentInformation(url: documentUrl, downloadStatus: documentStatus, sizeInBytes: Double(size))

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
@@ -171,7 +171,6 @@ public actor ContentExtractorStore: Log {
 
     private static func createSession(with documents: [Document]) -> LanguageModelSession {
         let docStats = Self.getDocumentStats(minTagCount: 3, maxSpecifications: 20, with: documents)
-        print(docStats)
         return LanguageModelSession(
             model: .default,
             tools: [],
@@ -214,6 +213,8 @@ public actor ContentExtractorStore: Log {
             .filter { $0.count >= minTagCount }
 
         let formattedTagCounts = tagCounts
+            // most frequently used tags first - the prompt tells the model to prefer them
+            .sorted { $0.count > $1.count }
             .prefix(30)
             .map {
                 "\($0.0):\($0.1)"

--- a/ArchiverLib/Sources/Shared/Other/DateParser.swift
+++ b/ArchiverLib/Sources/Shared/Other/DateParser.swift
@@ -51,7 +51,8 @@ nonisolated public enum DateParser: Log {
         }
 
         // the NSDataDetector parses times as "today" Date so we filter out all dates that are today
-        return detector.matches(in: raw, range: NSRange(location: 0, length: raw.count))
+        // NSRange must be based on UTF-16 units, otherwise matches at the end of non-ASCII content are missed
+        return detector.matches(in: raw, range: NSRange(raw.startIndex..., in: raw))
             .compactMap { match in
                 guard let date = match.date,
                       !Calendar.current.isDate(date, inSameDayAs: Date()) else { return nil }

--- a/iOS/PDFArchiverIOSApp.swift
+++ b/iOS/PDFArchiverIOSApp.swift
@@ -11,6 +11,14 @@ import SwiftUI
 
 @main
 struct PDFArchiverIOSApp: App {
+    init() {
+        // BGTaskScheduler requires all launch handlers to be registered
+        // before the end of the app launch sequence
+        if #available(iOS 26, *) {
+            BackgroundTaskManager.registerTaskHandlers()
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             RootView()


### PR DESCRIPTION
Closes #295 (all checklist items; the "out of scope" section stays open for separate decisions).

Stacked on #294 (same base branch) — will retarget to `develop` once #294 is merged.

## Changes

### Crash fixes
- OCR: skip broken images/pages instead of `fatalError` crashing the app
- iCloud: return `nil` for unknown download status values instead of `preconditionFailure`
- Settings (macOS): build mailto URL via `URLComponents` (was unencoded + force-unwrapped), remove always-firing debug assert

### Bug fixes
- `DateParser`: use UTF-16 based `NSRange`, so dates in non-ASCII content are not missed
- OCR: skip empty text observations that produced a NaN font expansion
- iCloud: match removed files by URL (deleted files cannot provide a uniqueId; fixes assertion noise on every deletion)
- Archive search: ignore empty search tokens (a lone space blanked the whole list)
- Archive search: derive default year suggestions from the current date (was hardcoded 2025/2024)
- Background tasks: register the `BGTaskScheduler` handler in the app initializer, as required before end of app launch
- Apple Intelligence prompt: sort tag stats by frequency before taking the top 30
- Remove `print` of private document data
- `BackgroundTaskManager`: check cancellation of the processing task, not the surrounding one
- `ArchiveStore.getUntaggedUrl` now delegates to `PathManager` (single source of truth, folder gets created)
- Document intentional `archivePathType` behavior on partially failed archive moves

## Verification
- `swift test`: 167 tests in 16 suites pass
- `xcodebuild` (macOS scheme): BUILD SUCCEEDED
- `ArchiverFeatures` cross-compiled for iOS simulator via SPM (local simulator destinations are currently broken)
- SwiftLint: no new violations in changed files