### PR TITLE
Fix background cache processing reporting 0 new caches

### DIFF
--- a/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/BackgroundTaskManager.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/Other/Dependencies/BackgroundTaskManager.swift
@@ -71,6 +71,11 @@ public actor BackgroundTaskManager: Log {
 
         // Use a cancellable task so the expiration handler can stop work
         let processingTask = Task {
+            // The background task may have launched the app in the background - in that case
+            // ArchiveStore has only just started its asynchronous folder scan and
+            // getDocuments() would return an empty snapshot.
+            await waitForInitialDocumentLoad()
+
             let documents = try await archiveStore.getDocuments()
             return await contentExtractorStore.processUntaggedDocumentsInBackground(
                 documents,
@@ -117,6 +122,25 @@ public actor BackgroundTaskManager: Log {
 
         // Reschedule for next time
         Self.scheduleCacheProcessing()
+    }
+
+    /// Wait until the initial document load has finished, but no longer than a fixed
+    /// timeout - the background execution window is limited.
+    private func waitForInitialDocumentLoad() async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                for await isLoading in await self.archiveStore.isLoading() {
+                    guard isLoading else { return }
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(30))
+                guard !Task.isCancelled else { return }
+                Logger.backgroundTask.warning("Timed out waiting for the initial document load")
+            }
+            await group.next()
+            group.cancelAll()
+        }
     }
 }
 #endif

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
@@ -134,6 +134,8 @@ public actor ContentExtractorStore: Log {
         var newCachesCreated = 0
 
         for document in untaggedDocuments {
+            guard !Task.isCancelled else { break }
+
             let documentId = document.id
 
             // Skip if already cached
@@ -143,24 +145,34 @@ public actor ContentExtractorStore: Log {
 
             // Extract text and process (cache will be saved inside extract())
             guard let text = await textExtractor(document.url) else {
+                Logger.contentExtractor.info("Skipping document without extractable text (e.g. not downloaded yet) - document ID: \(documentId)")
                 continue
             }
 
             do {
-                _ = try await extract(from: text,
-                                     customPrompt: customPrompt,
-                                     with: documents,
-                                     documentId: documentId)
-                newCachesCreated += 1
-                Logger.contentExtractor.debug("Background cache entry created for document ID: \(documentId)")
+                let info = try await extract(from: text,
+                                             customPrompt: customPrompt,
+                                             with: documents,
+                                             documentId: documentId)
+                if info != nil {
+                    newCachesCreated += 1
+                    Logger.contentExtractor.debug("Background cache entry created for document ID: \(documentId)")
+                } else {
+                    // e.g. the language model is currently not available
+                    Logger.contentExtractor.info("No cache entry created for document ID: \(documentId)")
+                }
             } catch {
                 Logger.contentExtractor.error("Failed to create cache entry in background for document ID \(documentId): \(error)")
             }
         }
 
-        // Prune cache entries for documents that no longer exist in untagged folder
-        let untaggedIds = Set(untaggedDocuments.map(\.id))
-        await cache.pruneCache(keepingOnly: untaggedIds)
+        // Prune cache entries for documents that no longer exist in untagged folder.
+        // Never prune while the document list is empty (e.g. the store has not finished
+        // loading) - that would wipe all valid cache entries.
+        if !documents.isEmpty {
+            let untaggedIds = Set(untaggedDocuments.map(\.id))
+            await cache.pruneCache(keepingOnly: untaggedIds)
+        }
 
         Logger.contentExtractor.info("Background cache processing completed: \(newCachesCreated) new caches created")
 


### PR DESCRIPTION
Closes #297

Stacked on #296 — will retarget once the chain merges.

## Changes
- `BackgroundTaskManager`: wait for the initial document load (30 s timeout) before processing — a background launch previously worked on an empty document snapshot, so the run always reported 0
- `ContentExtractorStore`: never prune the cache against an empty document list — this wiped all valid cache entries on every background run
- Only count cache entries that were actually created (`extract()` returning nil no longer counts)
- Log documents that are skipped because no text could be extracted (e.g. not downloaded from iCloud)
- Stop the processing loop when the background task is cancelled (expiration handler)

## Verification
- `swift test`: 167 tests in 16 suites pass
- `swift build` (macOS) and `ArchiverFeatures` cross-compiled for the iOS simulator triple
- SwiftLint: no violations in changed files