### PR TITLE
fix: stop blocking the cooperative pool in Vision OCR

### DIFF
--- a/ArchiverLib/Sources/DocumentProcessingPipeline/PDFOCREngine.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/PDFOCREngine.swift
@@ -154,76 +154,38 @@ enum PDFOCREngine {
 
     // MARK: - Shared core
 
-    /// Serial queue for the blocking Vision work.
-    ///
-    /// `VNImageRequestHandler.perform` blocks until recognition finished. Run
-    /// directly from an `async` function it would block a cooperative pool
-    /// thread, and the pool only has as many threads as the machine has cores -
-    /// a few concurrent OCR runs starve every other task in the process. Vision
-    /// is CPU bound anyway, so a *serial* queue is the right shape: it keeps
-    /// OCR off the cooperative pool without spawning a thread per page.
-    private static let visionQueue = DispatchQueue(label: "de.JulianKahnert.PDFArchiver.PDFOCREngine.vision",
-                                                  qos: .userInitiated)
-
-    /// Run Vision OCR on a single image and return detected text with positions.
+    /// Run Vision OCR on a single image and return recognized text with positions.
     /// Coordinates are in the image's coordinate system (origin top-left, y-down).
     ///
+    /// Uses the Swift `RecognizeTextRequest` (iOS 18 / macOS 15), which is
+    /// genuinely `async` - no thread is blocked, so this is safe to await
+    /// directly from the cooperative pool. It also recognizes the whole page in
+    /// a single Vision call: `RecognizedTextObservation` already carries the
+    /// bounding box of each recognized line, which the old
+    /// `VNDetectTextRectanglesRequest` + per-box `VNRecognizeTextRequest`
+    /// combination needed one extra Vision call per text box to produce.
+    ///
     /// - Parameters:
-    ///   - cgImage: The image to recognize. Passed as `CGImage` rather than
-    ///     `PlatformImage` because it has to cross onto ``visionQueue``.
+    ///   - cgImage: The image to recognize.
     ///   - imageSize: Size the observation coordinates are mapped into. This is
     ///     the `PlatformImage.size` of the source image, which is not
     ///     necessarily the pixel size of `cgImage`.
     static func recognizeText(in cgImage: CGImage, imageSize: CGSize) async throws -> [TextObservationResult] {
-        try await withCheckedThrowingContinuation { continuation in
-            visionQueue.async {
-                continuation.resume(with: Result { try recognizeTextBlocking(in: cgImage, imageSize: imageSize) })
-            }
+        var request = RecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        let observations = try await request.perform(on: cgImage)
+
+        return observations.compactMap { observation in
+            guard observation.confidence > confidenceThreshold,
+                  let candidate = observation.topCandidates(1).first,
+                  !candidate.string.isEmpty else { return nil }
+
+            // `.upperLeft` matches the y-down coordinate space the renderer draws in.
+            let rect = observation.boundingBox.toImageCoordinates(imageSize, origin: .upperLeft)
+            return TextObservationResult(rect: rect, text: candidate.string)
         }
-    }
-
-    /// The blocking Vision core. Must only be called on ``visionQueue``.
-    private static func recognizeTextBlocking(in cgImage: CGImage, imageSize: CGSize) throws -> [TextObservationResult] {
-        let requestHandler = VNImageRequestHandler(cgImage: cgImage, options: [:])
-
-        // Detect text rectangles.
-        var textRectObservations = [VNTextObservation]()
-        let textBoxRequest = VNDetectTextRectanglesRequest { request, error in
-            if let error {
-                Logger.ocrProcessing.error("Text detection failed: \(error)")
-                return
-            }
-            for observation in (request.results as? [VNTextObservation] ?? []) where observation.confidence > confidenceThreshold {
-                textRectObservations.append(observation)
-            }
-        }
-        try requestHandler.perform([textBoxRequest])
-
-        // Recognize text in each detected region.
-        var results = [TextObservationResult]()
-        for observation in textRectObservations {
-            let textBox = transform(observation: observation, in: imageSize)
-            guard let croppedImage = cgImage.cropping(to: textBox) else { continue }
-
-            let recognizeRequest = VNRecognizeTextRequest { request, error in
-                if let error {
-                    Logger.ocrProcessing.error("Text recognition failed: \(error)")
-                    return
-                }
-                guard let textResults = request.results as? [VNRecognizedTextObservation],
-                      !textResults.isEmpty else { return }
-                let texts = textResults.compactMap { $0.topCandidates(1).first?.string }
-                    .filter { !$0.isEmpty }
-                if !texts.isEmpty {
-                    results.append(TextObservationResult(rect: textBox, text: texts.joined(separator: " ")))
-                }
-            }
-            recognizeRequest.recognitionLevel = .accurate
-            recognizeRequest.usesLanguageCorrection = true
-            try? VNImageRequestHandler(cgImage: croppedImage, options: [:]).perform([recognizeRequest])
-        }
-
-        return results
     }
 
     /// Pre-compute the invisible attributed strings on the main actor, before
@@ -278,18 +240,6 @@ enum PDFOCREngine {
         guard let document = PDFDocument(data: data as Data),
               let page = document.page(at: 0) else { return nil }
         return page
-    }
-
-    private static func transform(observation: VNTextObservation, in imageSize: CGSize) -> CGRect {
-        // Special thanks to: https://github.com/g-r-a-n-t/serial-vision/
-        var transform = CGAffineTransform.identity
-        transform = transform.scaledBy(x: imageSize.width, y: -imageSize.height)
-        transform = transform.translatedBy(x: 0, y: -1)
-
-        return CGRect(x: observation.boundingBox.applying(transform).origin.x,
-                      y: observation.boundingBox.applying(transform).origin.y,
-                      width: observation.boundingBox.applying(transform).width,
-                      height: observation.boundingBox.applying(transform).height)
     }
 }
 

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/PDFOCREngine.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/PDFOCREngine.swift
@@ -72,7 +72,11 @@ enum PDFOCREngine {
                 continue
             }
 
-            let results = try recognizeText(in: image)
+            guard let cgImage = image.cgImage else {
+                Logger.ocrProcessing.error("Could not read page image \(url.lastPathComponent, privacy: .public)")
+                continue
+            }
+            let results = try await recognizeText(in: cgImage, imageSize: image.size)
             let textEntries = await makeTextEntries(from: results)
             let bounds = CGRect(origin: .zero, size: image.size)
 
@@ -114,7 +118,8 @@ enum PDFOCREngine {
             let imageSize = CGSize(width: bounds.width * renderScale, height: bounds.height * renderScale)
             let pageImage = page.thumbnail(of: imageSize, for: .mediaBox)
 
-            let ocrResults = try recognizeText(in: pageImage)
+            guard let pageCgImage = pageImage.cgImage else { continue }
+            let ocrResults = try await recognizeText(in: pageCgImage, imageSize: pageImage.size)
             guard !ocrResults.isEmpty else { continue }
 
             // Scale OCR coordinates back from the rendered image to page coordinates.
@@ -149,10 +154,36 @@ enum PDFOCREngine {
 
     // MARK: - Shared core
 
+    /// Serial queue for the blocking Vision work.
+    ///
+    /// `VNImageRequestHandler.perform` blocks until recognition finished. Run
+    /// directly from an `async` function it would block a cooperative pool
+    /// thread, and the pool only has as many threads as the machine has cores -
+    /// a few concurrent OCR runs starve every other task in the process. Vision
+    /// is CPU bound anyway, so a *serial* queue is the right shape: it keeps
+    /// OCR off the cooperative pool without spawning a thread per page.
+    private static let visionQueue = DispatchQueue(label: "de.JulianKahnert.PDFArchiver.PDFOCREngine.vision",
+                                                  qos: .userInitiated)
+
     /// Run Vision OCR on a single image and return detected text with positions.
     /// Coordinates are in the image's coordinate system (origin top-left, y-down).
-    static func recognizeText(in image: PlatformImage) throws -> [TextObservationResult] {
-        guard let cgImage = image.cgImage else { return [] }
+    ///
+    /// - Parameters:
+    ///   - cgImage: The image to recognize. Passed as `CGImage` rather than
+    ///     `PlatformImage` because it has to cross onto ``visionQueue``.
+    ///   - imageSize: Size the observation coordinates are mapped into. This is
+    ///     the `PlatformImage.size` of the source image, which is not
+    ///     necessarily the pixel size of `cgImage`.
+    static func recognizeText(in cgImage: CGImage, imageSize: CGSize) async throws -> [TextObservationResult] {
+        try await withCheckedThrowingContinuation { continuation in
+            visionQueue.async {
+                continuation.resume(with: Result { try recognizeTextBlocking(in: cgImage, imageSize: imageSize) })
+            }
+        }
+    }
+
+    /// The blocking Vision core. Must only be called on ``visionQueue``.
+    private static func recognizeTextBlocking(in cgImage: CGImage, imageSize: CGSize) throws -> [TextObservationResult] {
         let requestHandler = VNImageRequestHandler(cgImage: cgImage, options: [:])
 
         // Detect text rectangles.
@@ -171,7 +202,7 @@ enum PDFOCREngine {
         // Recognize text in each detected region.
         var results = [TextObservationResult]()
         for observation in textRectObservations {
-            let textBox = transform(observation: observation, in: image.size)
+            let textBox = transform(observation: observation, in: imageSize)
             guard let croppedImage = cgImage.cropping(to: textBox) else { continue }
 
             let recognizeRequest = VNRecognizeTextRequest { request, error in

--- a/ArchiverLib/Tests/DocumentProcessingPipelineTests/OCRTextLayerGeometryTests.swift
+++ b/ArchiverLib/Tests/DocumentProcessingPipelineTests/OCRTextLayerGeometryTests.swift
@@ -1,0 +1,66 @@
+//
+//  OCRTextLayerGeometryTests.swift
+//  ArchiverLib
+//
+
+import ArchiverModels
+import Foundation
+import PDFKit
+import Testing
+
+@testable import DocumentProcessingPipeline
+
+/// Guards the coordinate space of the invisible OCR text layer.
+///
+/// `PDFOCREngine` maps normalized Vision coordinates into a y-down image space
+/// and then into page space. A flipped origin or a wrong scale stays invisible
+/// in the other tests - the text layer is there, `hasTextLayer` is true and the
+/// page count matches - but text selection and search would land in the wrong
+/// place. This test compares *where* the text ends up against the real text
+/// layer of the same document.
+struct OCRTextLayerGeometryTests {
+
+    /// Words of `page`, grouped into horizontal bands of the page height.
+    private func wordsPerBand(_ page: PDFPage, bands: Int) -> [Set<String>] {
+        let bounds = page.bounds(for: .mediaBox)
+        return (0..<bands).map { index in
+            let bandRect = CGRect(x: bounds.minX,
+                                  y: bounds.minY + bounds.height * CGFloat(index) / CGFloat(bands),
+                                  width: bounds.width,
+                                  height: bounds.height / CGFloat(bands))
+            let text = page.selection(for: bandRect)?.string ?? ""
+            return Set(text.lowercased()
+                .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                .filter { $0.count >= 4 })
+        }
+    }
+
+    @Test(.tags(.ocr))
+    func ocrTextLandsInTheSameBandAsTheOriginal() async throws {
+        let bands = 4
+
+        // Reference: the original PDF and its real text layer.
+        let sourcePdf = try #require(PDFDocument(url: Bundle.billPDFUrl))
+        let sourcePage = try #require(sourcePdf.page(at: 0))
+        let referenceBands = wordsPerBand(sourcePage, bands: bands)
+
+        // Subject: the same page rasterized, then OCR'd back into a text layer.
+        let bounds = sourcePage.bounds(for: .mediaBox)
+        let image = sourcePage.thumbnail(of: CGSize(width: bounds.width * 3, height: bounds.height * 3),
+                                        for: .mediaBox)
+        let pdf = PDFMetadataTests.createImageOnlyPDF(from: image)
+        try await PDFOCREngine.addTextLayer(to: pdf, quality: .lossless)
+        let ocrBands = wordsPerBand(try #require(pdf.page(at: 0)), bands: bands)
+
+        let referenceCount = referenceBands.reduce(0) { $0 + $1.count }
+        let sameBandCount = zip(referenceBands, ocrBands).reduce(0) { $0 + $1.0.intersection($1.1).count }
+        try #require(referenceCount > 0)
+
+        // Words the OCR missed entirely count against this ratio too, so the
+        // threshold stays well below the ~86% observed on real hardware.
+        // A flipped or mis-scaled layer scatters words and drops far lower.
+        let sameBandRatio = Double(sameBandCount) / Double(referenceCount)
+        #expect(sameBandRatio > 0.6,
+                "only \(sameBandCount)/\(referenceCount) words landed in their original band - text layer misaligned")
+    }
+}

--- a/ArchiverLib/Tests/DocumentProcessingPipelineTests/helper/Tags.swift
+++ b/ArchiverLib/Tests/DocumentProcessingPipelineTests/helper/Tags.swift
@@ -8,13 +8,10 @@ import Testing
 extension Tag {
     /// Tests that run real Vision text recognition.
     ///
-    /// They rasterize a full page at 3x and run one `VNRecognizeTextRequest`
-    /// per detected text rectangle - a few seconds each on real hardware, but
-    /// unbounded on the GitHub Actions VM, which has no GPU/Neural Engine
-    /// access ("IOServiceMatching failed for: AppleM2ScalerParavirtDriver").
-    /// Because `PDFOCREngine.recognizeText(in:)` blocks its thread, several of
-    /// them in parallel also starve the cooperative pool and wedge the whole
-    /// test run. The `ArchiverLib-CI` test plan therefore excludes this tag;
-    /// the default `ArchiverLib` plan runs them locally.
+    /// They rasterize a full page at 3x and run it through Vision - a few
+    /// seconds each on real hardware, but unbounded on the GitHub Actions VM,
+    /// which has no GPU/Neural Engine access ("IOServiceMatching failed for:
+    /// AppleM2ScalerParavirtDriver"). The `ArchiverLib-CI` test plan therefore
+    /// excludes this tag; the default `ArchiverLib` plan runs them locally.
     @Tag static var ocr: Self
 }


### PR DESCRIPTION
## Changes
- Move `VNImageRequestHandler.perform` off the cooperative thread pool
- Replace `VNDetectTextRectanglesRequest` + per-box `VNRecognizeTextRequest` with a single async `RecognizeTextRequest` (iOS 18 / macOS 15)
- `recognizeText` is now `async` and takes `CGImage` + size, so only Sendable values cross isolation boundaries
- Add a text layer geometry regression test (tagged `ocr`)

## Why
`VNImageRequestHandler.perform` blocks until recognition finished. Called straight from an `async` function it blocked a cooperative pool thread, and the pool has only one thread per core — a few concurrent OCR runs starved every other task in the process. This is what wedged the whole test run in #285.

## Measured on the bill fixture
| | before | after |
| --- | --- | --- |
| recognition | 2.40s | 0.25s |
| `addTextLayer` | 6.17s | 0.77s |
| observations | 38 | 38 |
| word agreement | — | 98.4% Jaccard, no word lost |
| box IoU | — | mean 0.62, 0/38 displaced |

Two commits: the isolation fix alone, then the API modernisation, so the second can be reverted independently.