### PR TITLE
fix: improve AI tag suggestions

### DIFF
--- a/ArchiverLib/Sources/ArchiverFeatures/DocumentInformationForm/DocumentInformationForm.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/DocumentInformationForm/DocumentInformationForm.swift
@@ -167,7 +167,7 @@ struct DocumentInformationForm {
             case .onTagSuggestionTapped(var tag):
                 tag = tag.lowercased()
                 _ = state.document.tags.insert(tag)
-                state.suggestedTags.removeAll { $0 == tag }
+                state.suggestedTags.removeAll { $0.lowercased() == tag }
 
                 // remove current tagSearchteam
                 state.tagSearchterm = ""
@@ -249,13 +249,14 @@ struct DocumentInformationForm {
                     state.suggestedDates = dateSuggestions
                 }
                 if let tagSuggestions = result.tagSuggestions {
-                    state.suggestedTags = tagSuggestions
+                    let documentTags = Set(state.document.tags.map { $0.lowercased() })
+                    state.suggestedTags = tagSuggestions.filter { !documentTags.contains($0.lowercased()) }
                 }
                 return .none
 
             case .updateTagSuggestions(let suggestedTags):
                 state.isLoading = false
-                state.suggestedTags = suggestedTags
+                state.suggestedTags = suggestedTags.sorted()
                 return .none
 
             case .updateTagSelectionDelayProgress(let progress):

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractionMapper.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractionMapper.swift
@@ -22,15 +22,18 @@ struct RawDocumentInformation: Equatable, Sendable {
 enum ContentExtractionMapper {
 
     /// Maximum number of tags kept from the model output.
-    static let maxTags = 10
+    static let maxTags = 4
 
     /// Normalize the raw model output: trim the description, and slug-clean the
     /// tags (remove symbols/whitespace) keeping at most `maxTags`.
     static func normalize(_ raw: RawDocumentInformation) -> (specification: String, tags: [String]) {
         let specification = raw.description.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var seen = Set<String>()
         let tags = raw.tags
             .map(normalizeTag)
             .filter(isValidTag)
+            .filter { seen.insert($0).inserted }
         return (specification, Array(tags.prefix(maxTags)))
     }
 
@@ -42,7 +45,7 @@ enum ContentExtractionMapper {
         if let match = tag.firstMatch(of: /^(.*?)[:#]\s*\d+$/) {
             tag = String(match.1)
         }
-        return tag.slugified(withSeparator: "")
+        return tag.slugified(withSeparator: "").lowercased()
     }
 
     /// Purely numeric tags carry no meaning for the archive (tags with digits

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractionPromptFactory.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractionPromptFactory.swift
@@ -24,8 +24,8 @@ enum ContentExtractionPromptFactory {
     private static let charactersPerToken = 2
 
     /// Tokens reserved for the instruction segments (incl. tag/description
-    /// statistics) and the structured response.
-    private static let reservedTokens = 1536
+    /// statistics), the injected response schema and the structured response.
+    private static let reservedTokens = 2048
 
     /// Minimum number of occurrences for a tag to be offered to the model.
     static let minTagCount = 3
@@ -86,11 +86,17 @@ enum ContentExtractionPromptFactory {
     If the document content does not contain enough information to create good tags/description, you MUST NOT hallucinate them - just return empty values.
     """
 
-    static func tagsInstruction(stats: DocumentStats) -> String {
-        """
-        Tags MUST ALWAYS use existing tags from the system whenever applicable.
-        Prefer the existing tags, ordered by most frequently used first: \(stats.tags.prefix(maxStatLength))
+    static func tagsInstruction(stats: DocumentStats, locale: Locale) -> String {
+        let existingTags = stats.tags.isEmpty
+            ? ""
+            : "\nPrefer the existing tags, ordered by most frequently used first: \(stats.tags.prefix(maxStatLength))"
+
+        return """
+        Tags MUST ALWAYS use existing tags from the system whenever applicable.\(existingTags)
         If no suitable existing tags are found, create new appropriate tags.
+        You MUST ALWAYS use the user's locale: \(locale.identifier).
+        Every tag MUST be a single lowercase word without symbols - never a multi-word phrase.
+        Aim for 2-4 tags, but return fewer or none if the document content does not support them.
         """
     }
 

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
@@ -205,7 +205,7 @@ public actor ContentExtractorStore {
         let response = try await session.respond(
             to: prompt,
             generating: DocumentInformation.self,
-            includeSchemaInPrompt: false,
+            includeSchemaInPrompt: true,
             options: options
         )
 
@@ -220,8 +220,8 @@ public actor ContentExtractorStore {
             tools: [],
             instructions: Instructions {
                 ContentExtractionPromptFactory.taskInstruction
-                ContentExtractionPromptFactory.tagsInstruction(stats: stats)
                 ContentExtractionPromptFactory.descriptionInstruction(stats: stats, locale: Self.locale)
+                ContentExtractionPromptFactory.tagsInstruction(stats: stats, locale: Self.locale)
             }
         )
     }
@@ -234,7 +234,7 @@ extension ContentExtractorStore {
         @Guide(description: "short document description")
         var description: String
 
-        @Guide(description: "document tags; lowercase; no symbols", .maximumCount(10))
+        @Guide(description: "document tags; lowercase; no symbols", .maximumCount(ContentExtractionMapper.maxTags))
         var tags: [String]
     }
 

--- a/ArchiverLib/Sources/Shared/Other/SharedKeys.swift
+++ b/ArchiverLib/Sources/Shared/Other/SharedKeys.swift
@@ -31,29 +31,31 @@ enum Names: String {
 /// `true` if the tutorial was already shown
 public extension SharedKey where Self == AppStorageKey<Bool> {
   static var tutorialShown: Self {
-      appStorage(Names.tutorialShown.id, store: .standard)
+      appStorage(Names.tutorialShown.id)
   }
 }
 public extension SharedKey where Self == AppStorageKey<Bool>.Default {
   static var tutorialShown: Self {
+      @Dependency(\.defaultAppStorage) var store
       // try to fetch the value from a previous version
-      let defaultValue = (UserDefaults.standard.value(forKey: "tutorial-v1") as? Bool) ?? false
-      return Self[.appStorage(Names.tutorialShown.id, store: .standard), default: defaultValue]
+      let defaultValue = (store.value(forKey: "tutorial-v1") as? Bool) ?? false
+      return Self[.appStorage(Names.tutorialShown.id), default: defaultValue]
   }
 }
 
 /// Default quality of a the images that will be processed to a PDF document
 public extension SharedKey where Self == AppStorageKey<Float> {
     static var pdfQuality: Self {
-        appStorage(Names.pdfQuality.id, store: .standard)
+        appStorage(Names.pdfQuality.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<PDFQuality>.Default {
   static var pdfQuality: Self {
+      @Dependency(\.defaultAppStorage) var store
       let defaultValue: PDFQuality
 
       // try to fetch the value from a previous version
-      if let oldValue = UserDefaults.standard.value(forKey: "pdfQuality") as? Float,
+      if let oldValue = store.value(forKey: "pdfQuality") as? Float,
          oldValue != 0,
         let oldPdfQuality = PDFQuality(rawValue: oldValue) {
           defaultValue = oldPdfQuality
@@ -61,116 +63,119 @@ public extension SharedKey where Self == AppStorageKey<PDFQuality>.Default {
           defaultValue = .lossless
       }
 
-      return Self[.appStorage(Names.pdfQuality.id, store: .standard), default: defaultValue]
+      return Self[.appStorage(Names.pdfQuality.id), default: defaultValue]
   }
 }
 
 public extension SharedKey where Self == AppStorageKey<Bool> {
     static var notSaveDocumentTagsAsPDFMetadata: Self {
-        appStorage(Names.notSaveDocumentTagsAsPDFMetadata.id, store: .standard)
+        appStorage(Names.notSaveDocumentTagsAsPDFMetadata.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<Bool>.Default {
   static var notSaveDocumentTagsAsPDFMetadata: Self {
+      @Dependency(\.defaultAppStorage) var store
       // try to fetch the value from a previous version
-      let defaultValue = UserDefaults.standard.bool(forKey: "notSaveDocumentTagsAsPDFMetadata")
-      return Self[.appStorage(Names.notSaveDocumentTagsAsPDFMetadata.id, store: .standard), default: defaultValue]
+      let defaultValue = store.bool(forKey: "notSaveDocumentTagsAsPDFMetadata")
+      return Self[.appStorage(Names.notSaveDocumentTagsAsPDFMetadata.id), default: defaultValue]
   }
 }
 
 public extension SharedKey where Self == AppStorageKey<Bool> {
     static var documentTagsNotRequired: Self {
-        appStorage(Names.documentTagsNotRequired.id, store: .standard)
+        appStorage(Names.documentTagsNotRequired.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<Bool>.Default {
   static var documentTagsNotRequired: Self {
+      @Dependency(\.defaultAppStorage) var store
       // try to fetch the value from a previous version
-      let defaultValue = UserDefaults.standard.bool(forKey: "documentTagsNotRequired")
-      return Self[.appStorage(Names.documentTagsNotRequired.id, store: .standard), default: defaultValue]
+      let defaultValue = store.bool(forKey: "documentTagsNotRequired")
+      return Self[.appStorage(Names.documentTagsNotRequired.id), default: defaultValue]
   }
 }
 
 public extension SharedKey where Self == AppStorageKey<Bool> {
     static var documentSpecificationNotRequired: Self {
-        appStorage(Names.documentSpecificationNotRequired.id, store: .standard)
+        appStorage(Names.documentSpecificationNotRequired.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<Bool>.Default {
   static var documentSpecificationNotRequired: Self {
+      @Dependency(\.defaultAppStorage) var store
       // try to fetch the value from a previous version
-      let defaultValue = UserDefaults.standard.bool(forKey: "documentSpecificationNotRequired")
-      return Self[.appStorage(Names.documentSpecificationNotRequired.id, store: .standard), default: defaultValue]
+      let defaultValue = store.bool(forKey: "documentSpecificationNotRequired")
+      return Self[.appStorage(Names.documentSpecificationNotRequired.id), default: defaultValue]
   }
 }
 
 public extension SharedKey where Self == AppStorageKey<Bool> {
     static var appleIntelligenceEnabled: Self {
-        appStorage(Names.appleIntelligenceEnabled.id, store: .standard)
+        appStorage(Names.appleIntelligenceEnabled.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<Bool>.Default {
   static var appleIntelligenceEnabled: Self {
-      return Self[.appStorage(Names.appleIntelligenceEnabled.id, store: .standard), default: true]
+      return Self[.appStorage(Names.appleIntelligenceEnabled.id), default: true]
   }
 }
 
 public extension SharedKey where Self == AppStorageKey<String?> {
     static var appleIntelligenceCustomPrompt: Self {
-        appStorage(Names.appleIntelligenceCustomPrompt.id, store: .standard)
+        appStorage(Names.appleIntelligenceCustomPrompt.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<String?>.Default {
   static var appleIntelligenceCustomPrompt: Self {
-      return Self[.appStorage(Names.appleIntelligenceCustomPrompt.id, store: .standard), default: nil]
+      return Self[.appStorage(Names.appleIntelligenceCustomPrompt.id), default: nil]
   }
 }
 
 public extension SharedKey where Self == AppStorageKey<Bool> {
     static var appleIntelligenceCacheEnabled: Self {
-        appStorage(Names.appleIntelligenceCacheEnabled.id, store: .standard)
+        appStorage(Names.appleIntelligenceCacheEnabled.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<Bool>.Default {
   static var appleIntelligenceCacheEnabled: Self {
-      return Self[.appStorage(Names.appleIntelligenceCacheEnabled.id, store: .standard), default: true]
+      return Self[.appStorage(Names.appleIntelligenceCacheEnabled.id), default: true]
   }
 }
 
 public extension SharedKey where Self == AppStorageKey<Bool> {
     static var backgroundCacheNotificationsEnabled: Self {
-        appStorage(Names.backgroundCacheNotificationsEnabled.id, store: .standard)
+        appStorage(Names.backgroundCacheNotificationsEnabled.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<Bool>.Default {
   static var backgroundCacheNotificationsEnabled: Self {
-      return Self[.appStorage(Names.backgroundCacheNotificationsEnabled.id, store: .standard), default: false]
+      return Self[.appStorage(Names.backgroundCacheNotificationsEnabled.id), default: false]
   }
 }
 
 public extension SharedKey where Self == AppStorageKey<Bool> {
     static var multiTagSelectionDelayEnabled: Self {
-        appStorage(Names.multiTagSelectionDelayEnabled.id, store: .standard)
+        appStorage(Names.multiTagSelectionDelayEnabled.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<Bool>.Default {
   static var multiTagSelectionDelayEnabled: Self {
-      return Self[.appStorage(Names.multiTagSelectionDelayEnabled.id, store: .standard), default: true]
+      return Self[.appStorage(Names.multiTagSelectionDelayEnabled.id), default: true]
   }
 
   static var ocrEnabled: Self {
-      return Self[.appStorage(Names.ocrEnabled.id, store: .standard), default: false]
+      return Self[.appStorage(Names.ocrEnabled.id), default: false]
   }
 }
 
 public extension SharedKey where Self == AppStorageKey<Bool> {
     static var highlightDetectedDateEnabled: Self {
-        appStorage(Names.highlightDetectedDateEnabled.id, store: .standard)
+        appStorage(Names.highlightDetectedDateEnabled.id)
     }
 }
 public extension SharedKey where Self == AppStorageKey<Bool>.Default {
   static var highlightDetectedDateEnabled: Self {
-      return Self[.appStorage(Names.highlightDetectedDateEnabled.id, store: .standard), default: true]
+      return Self[.appStorage(Names.highlightDetectedDateEnabled.id), default: true]
   }
 }
 
@@ -198,14 +203,16 @@ public extension SharedKey where Self == FileStorageKey<IdentifiedArrayOf<Docume
 
 public extension SharedKey where Self == ArchivePathTypeCustomSharedKey {
   static var archivePathType: Self {
-      ArchivePathTypeCustomSharedKey(key: "archivePathType", store: .standard)
+      @Dependency(\.defaultAppStorage) var store
+      return ArchivePathTypeCustomSharedKey(key: "archivePathType", store: store)
   }
 }
 
 #if os(macOS)
 public extension SharedKey where Self == ObservedFolderCustomSharedKey {
   static var observedFolder: Self {
-      ObservedFolderCustomSharedKey(key: "observedFolderURL", store: .standard)
+      @Dependency(\.defaultAppStorage) var store
+      return ObservedFolderCustomSharedKey(key: "observedFolderURL", store: store)
   }
 }
 #endif

--- a/ArchiverLib/Tests/ArchiverFeaturesTests/DocumentInformationFormTests.swift
+++ b/ArchiverLib/Tests/ArchiverFeaturesTests/DocumentInformationFormTests.swift
@@ -214,8 +214,8 @@ struct DocumentInformationFormTests {
             DocumentInformationForm()
         }
 
-        await store.send(.updateTagSuggestions(["suggestion1", "suggestion2"])) {
-            $0.suggestedTags = ["suggestion1", "suggestion2"]
+        await store.send(.updateTagSuggestions(["zebra", "apfel"])) {
+            $0.suggestedTags = ["apfel", "zebra"]
         }
     }
 
@@ -283,6 +283,67 @@ struct DocumentInformationFormTests {
             $0.document.tags = ["invoice", "tax"]
             $0.suggestedDates = [date]
             $0.suggestedTags = ["business", "finance"]
+        }
+    }
+
+    @Test
+    func aiTagSuggestionsAreSortedAlphabetically() async throws {
+        let date = try Date("2025-07-26T15:00:0Z", strategy: .iso8601)
+        let document = Document.mock()
+        let modelTags: Set<String> = ["zebra", "hoodie", "apfel"]
+
+        @Shared(.appleIntelligenceEnabled) var appleIntelligenceEnabled
+        $appleIntelligenceEnabled.withLock { $0 = true }
+
+        let store = TestStore(initialState: DocumentInformationForm.State(document: document)) {
+            DocumentInformationForm()
+        } withDependencies: {
+            $0.archiveStore.parseFilename = { _ in (date, nil, nil) }
+            $0.archiveStore.getDocuments = { [] }
+            $0.textAnalyser.getTextFrom = { _ in "document text" }
+            $0.textAnalyser.parseDateFrom = { _ in [] }
+            $0.textAnalyser.getFileTagsFrom = { _ in [] }
+            $0.contentExtractorStore.isAvailable = { .available }
+            $0.contentExtractorStore.getDocumentInformation = { _ in
+                .init(specification: "blue hoodie", tags: modelTags)
+            }
+        }
+
+        await store.send(.startUpdatingAllSuggestionsWithAI(document.url))
+
+        let expectedResult = DocumentInformationForm.DocumentParsingResult(
+            date: date,
+            specification: "blue hoodie",
+            tags: [],
+            dateSuggestions: [],
+            tagSuggestions: ["apfel", "hoodie", "zebra"])
+        await store.receive(.updateDocumentData(expectedResult)) {
+            $0.document.date = date
+            $0.document.specification = "blue hoodie"
+            $0.suggestedTags = ["apfel", "hoodie", "zebra"]
+        }
+    }
+
+    @Test
+    func updateDocumentDataDropsSuggestionsAlreadyOnDocument() async throws {
+        let store = TestStore(initialState: DocumentInformationForm.State(document: .mock())) {
+            DocumentInformationForm()
+        }
+
+        let date = Date()
+        let parsingResult = DocumentInformationForm.DocumentParsingResult(
+            date: date,
+            specification: "invoice-2024",
+            tags: ["invoice", "tax"],
+            dateSuggestions: nil,
+            tagSuggestions: ["Invoice", "business", "tax"]
+        )
+
+        await store.send(.updateDocumentData(parsingResult)) {
+            $0.document.date = date
+            $0.document.specification = "invoice-2024"
+            $0.document.tags = ["invoice", "tax"]
+            $0.suggestedTags = ["business"]
         }
     }
 

--- a/ArchiverLib/Tests/ArchiverFeaturesTests/SharedKeysTests.swift
+++ b/ArchiverLib/Tests/ArchiverFeaturesTests/SharedKeysTests.swift
@@ -1,0 +1,54 @@
+//
+//  SharedKeysTests.swift
+//  ArchiverLib
+//
+//  Regression tests for the app storage isolation of the shared keys.
+//
+
+import ComposableArchitecture
+import Foundation
+import Testing
+
+@testable import ArchiverFeatures
+
+@Suite("SharedKeys app storage isolation")
+struct SharedKeysTests {
+
+    @Test("A value written in one dependency scope does not leak into another")
+    func appStorageIsIsolatedBetweenScopes() {
+        withDependencies {
+            $0.defaultAppStorage = .inMemory
+        } operation: {
+            @Shared(.appleIntelligenceEnabled) var appleIntelligenceEnabled
+            $appleIntelligenceEnabled.withLock { $0 = false }
+            #expect(appleIntelligenceEnabled == false)
+        }
+
+        withDependencies {
+            $0.defaultAppStorage = .inMemory
+        } operation: {
+            @Shared(.appleIntelligenceEnabled) var appleIntelligenceEnabled
+            #expect(appleIntelligenceEnabled == true)
+        }
+    }
+
+    @Test("The legacy migration default reads the injected store")
+    func legacyMigrationUsesTheInjectedStore() {
+        let storeWithLegacyValue = UserDefaults.inMemory
+        storeWithLegacyValue.set(true, forKey: "documentTagsNotRequired")
+
+        withDependencies {
+            $0.defaultAppStorage = storeWithLegacyValue
+        } operation: {
+            @Shared(.documentTagsNotRequired) var documentTagsNotRequired
+            #expect(documentTagsNotRequired == true)
+        }
+
+        withDependencies {
+            $0.defaultAppStorage = .inMemory
+        } operation: {
+            @Shared(.documentTagsNotRequired) var documentTagsNotRequired
+            #expect(documentTagsNotRequired == false)
+        }
+    }
+}

--- a/ArchiverLib/Tests/ContentExtractorStoreTests/ContentExtractorStoreUnitTests.swift
+++ b/ArchiverLib/Tests/ContentExtractorStoreTests/ContentExtractorStoreUnitTests.swift
@@ -107,12 +107,37 @@ struct ContentExtractionPromptFactoryTests {
     @Test("Instruction segments embed the locale and the stats")
     func instructionSegmentsContainContext() {
         let stats = ContentExtractionPromptFactory.documentStats(from: [doc("eine rechnung", ["rechnung", "auto", "haus"])])
-        let tagsInstruction = ContentExtractionPromptFactory.tagsInstruction(stats: stats)
+        let tagsInstruction = ContentExtractionPromptFactory.tagsInstruction(stats: stats, locale: Locale(identifier: "de_DE"))
         let descriptionInstruction = ContentExtractionPromptFactory.descriptionInstruction(stats: stats, locale: Locale(identifier: "de_DE"))
 
         #expect(tagsInstruction.contains("existing tags"))
         #expect(descriptionInstruction.contains("de_DE"))
         #expect(descriptionInstruction.contains("DO NOT hallucinate"))
+    }
+
+    @Test("Tags instruction embeds the locale")
+    func tagsInstructionContainsLocale() {
+        let stats = ContentExtractionPromptFactory.documentStats(from: [doc("eine rechnung", ["rechnung", "auto", "haus"])])
+        let instruction = ContentExtractionPromptFactory.tagsInstruction(stats: stats, locale: Locale(identifier: "de_DE"))
+
+        #expect(instruction.contains("de_DE"))
+    }
+
+    @Test("Tags instruction without existing tags has no dangling colon but keeps the rules")
+    func tagsInstructionWithoutExistingTags() {
+        let stats = ContentExtractionPromptFactory.documentStats(from: [doc("eine rechnung", ["rechnung"])])
+        #expect(stats.tags.isEmpty)
+
+        let instruction = ContentExtractionPromptFactory.tagsInstruction(stats: stats, locale: Locale(identifier: "de_DE"))
+
+        #expect(!instruction.contains("most frequently used first"))
+        #expect(!instruction.contains(":\n"))
+        #expect(!instruction.hasSuffix(":"))
+
+        #expect(instruction.contains("create new appropriate tags"))
+        #expect(instruction.contains("de_DE"))
+        #expect(instruction.contains("single lowercase word"))
+        #expect(instruction.contains("2-4 tags"))
     }
 }
 
@@ -127,12 +152,27 @@ struct ContentExtractionMapperTests {
                                          tags: ["Tom-Tailor", "Rechnung!", "über"])
         let result = ContentExtractionMapper.normalize(raw)
         #expect(result.specification == "Tom Tailor Jeans")
-        #expect(result.tags == ["TomTailor", "Rechnung", "ueber"])
+        #expect(result.tags == ["tomtailor", "rechnung", "ueber"])
+    }
+
+    @Test("Lowercases the tags")
+    func normalizeLowercasesTags() {
+        let raw = RawDocumentInformation(description: "x", tags: ["Rechnung", "AUTO", "Über"])
+        let result = ContentExtractionMapper.normalize(raw)
+        #expect(result.tags == ["rechnung", "auto", "ueber"])
+    }
+
+    @Test("Deduplicates tags stably and keeps the model's order")
+    func normalizeDeduplicatesStably() {
+        let raw = RawDocumentInformation(description: "x",
+                                         tags: ["rechnung", "auto", "Rechnung", "Tom-Tailor", "auto", "tom tailor"])
+        let result = ContentExtractionMapper.normalize(raw)
+        #expect(result.tags == ["rechnung", "auto", "tomtailor"])
     }
 
     @Test("Caps the number of tags")
     func normalizeCapsTagCount() {
-        let raw = RawDocumentInformation(description: "x", tags: Array(repeating: "tag", count: 25))
+        let raw = RawDocumentInformation(description: "x", tags: (0..<25).map { "tag\($0)" })
         let result = ContentExtractionMapper.normalize(raw)
         #expect(result.tags.count == ContentExtractionMapper.maxTags)
     }
@@ -191,7 +231,7 @@ struct ContentExtractorStoreOrchestrationTests {
         }
         let info = try #require(try await store.extract(from: "text", with: []))
         #expect(info.specification == "Tom Tailor Jeans")
-        #expect(info.tags == ["TomTailor", "Rechnung", "kleidung"])
+        #expect(info.tags == ["tomtailor", "rechnung", "kleidung"])
     }
 
     @Test("Returns nil and does not call the model when unavailable")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Code Comments
 - **ALL code comments MUST be in English**
 - No exceptions for any programming language files
+- Explain **why**, not what — the code already states what it does
+- **Max 2 lines**; go longer only when the reason genuinely requires it, e.g. a
+  non-obvious failure mode or a deliberately rejected alternative
+- Delete comments that only restate the line below them
 
 ## Project Overview
 


### PR DESCRIPTION
## Changes

- Inject the response schema so the tag `@Guide` rules reach the model
- Tag instruction: guard the empty case, add locale, word and count rules
- Move the tag instruction next to the user prompt
- Lowercase, deduplicate and cap tag suggestions at 4
- Drop suggestions already on the document
- Always sort tag suggestions alphabetically, in the store
- Resolve shared app storage via `@Dependency(\.defaultAppStorage)` instead of pinning `store: .standard`
- `CLAUDE.md`: comments explain why, not what, max 2 lines