### PR TITLE
fix: detect broken PDF text layers

### DIFF
--- a/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/PDFInfoView.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/PDFInfoView.swift
@@ -29,8 +29,7 @@ struct PDFInfoView: View {
         }
 
         return PDFInfo(
-            // Same check the OCR pass uses, so a document the pass considers
-            // image-only is never advertised as searchable here.
+            // Same check as the OCR pass, so the badge cannot disagree with it.
             hasTextLayer: pdf.map { PDFMetadata.hasTextLayer($0) } ?? false,
             pageCount: pdf?.pageCount ?? 0,
             fileSize: fileSize,

--- a/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/PDFInfoView.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/DocumentDetails/PDFInfoView.swift
@@ -5,6 +5,7 @@
 //  Created by Julian Kahnert on 22.02.26.
 //
 
+import DocumentProcessingPipeline
 import PDFKit
 import Shared
 import SwiftUI
@@ -28,9 +29,9 @@ struct PDFInfoView: View {
         }
 
         return PDFInfo(
-            hasTextLayer: (0..<min(pdf?.pageCount ?? 0, 3)).contains {
-                pdf?.page(at: $0)?.string?.isEmpty == false
-            },
+            // Same check the OCR pass uses, so a document the pass considers
+            // image-only is never advertised as searchable here.
+            hasTextLayer: pdf.map { PDFMetadata.hasTextLayer($0) } ?? false,
             pageCount: pdf?.pageCount ?? 0,
             fileSize: fileSize,
             creationDate: meta?[PDFDocumentAttribute.creationDateAttribute] as? Date,

--- a/ArchiverLib/Sources/ArchiverModels/TextReadability.swift
+++ b/ArchiverLib/Sources/ArchiverModels/TextReadability.swift
@@ -1,0 +1,68 @@
+//
+//  TextReadability.swift
+//  ArchiverLib
+//
+//  Created by Julian Kahnert on 10.08.26.
+//
+
+import Foundation
+
+/// Heuristic that tells apart real document text from the mojibake a broken PDF
+/// text layer produces.
+///
+/// Scanners and third-party OCR tools sometimes ship a text layer whose
+/// `ToUnicode` CMap does not match the embedded font subset. The PDF then
+/// *has* text - `PDFPage.string` returns 2000 characters - but every letter is
+/// mapped to an arbitrary other character, so the result reads like
+/// `I9Aü9O-P$p$P$Ax31J(Pü3VWA3`. Such text must neither count as a usable text
+/// layer nor be handed to the language model.
+///
+/// The signal used is the share of letters that sit in word-like runs: a
+/// substitution of this kind scatters digits and symbols across every word, so
+/// long uninterrupted letter runs practically disappear. Measured over 265 real
+/// archive documents the share never dropped below 0.73 - not for number-heavy
+/// invoices and payslips, and not where PDFKit swallowed every space - while
+/// the broken layer above scores 0.30.
+public enum TextReadability {
+
+    /// Letters in an uninterrupted run of at least this length are counted as
+    /// belonging to a word.
+    static let minimumRunLength = 4
+
+    /// Minimum share of letters that must sit in word-like runs.
+    static let minimumWordLetterShare = 0.5
+
+    /// Below this many letters the sample is too small to judge - a short
+    /// header is not enough evidence to declare a document unreadable.
+    static let minimumLetterCount = 50
+
+    /// Returns `true` if `text` plausibly contains real words.
+    ///
+    /// Errs on the side of `true`: both call sites act destructively on a
+    /// `false` (re-rasterizing a page, dropping AI suggestions), so only a
+    /// clear verdict should trigger them.
+    public static func isReadable(_ text: String) -> Bool {
+        var totalLetters = 0
+        var wordLetters = 0
+        var runLength = 0
+
+        for character in text {
+            if character.isLetter {
+                runLength += 1
+                continue
+            }
+            totalLetters += runLength
+            if runLength >= minimumRunLength {
+                wordLetters += runLength
+            }
+            runLength = 0
+        }
+        totalLetters += runLength
+        if runLength >= minimumRunLength {
+            wordLetters += runLength
+        }
+
+        guard totalLetters >= minimumLetterCount else { return true }
+        return Double(wordLetters) / Double(totalLetters) >= minimumWordLetterShare
+    }
+}

--- a/ArchiverLib/Sources/ArchiverModels/TextReadability.swift
+++ b/ArchiverLib/Sources/ArchiverModels/TextReadability.swift
@@ -7,55 +7,34 @@
 
 import Foundation
 
-/// Heuristic that tells apart real document text from the mojibake a broken PDF
-/// text layer produces.
+/// Tells real document text apart from the mojibake of a broken PDF text layer,
+/// where a `ToUnicode` CMap that does not match its font subset turns
+/// `Mandatsreferenz (wird von` into `I9Aü9O-P$p$P$Ax31J(Pü3VWA3`.
 ///
-/// Scanners and third-party OCR tools sometimes ship a text layer whose
-/// `ToUnicode` CMap does not match the embedded font subset. The PDF then
-/// *has* text - `PDFPage.string` returns 2000 characters - but every letter is
-/// mapped to an arbitrary other character, so the result reads like
-/// `I9Aü9O-P$p$P$Ax31J(Pü3VWA3`. Such text must neither count as a usable text
-/// layer nor be handed to the language model.
+/// Such a substitution scatters digits and symbols through every word, so the
+/// share of letters in word-like runs collapses: 0.30 for that layer, never
+/// below 0.73 across 265 real archive documents.
 ///
-/// The signal used is the share of letters that sit in word-like runs: a
-/// substitution of this kind scatters digits and symbols across every word, so
-/// long uninterrupted letter runs practically disappear. Measured over 265 real
-/// archive documents the share never dropped below 0.73 - not for number-heavy
-/// invoices and payslips, and not where PDFKit swallowed every space - while
-/// the broken layer above scores 0.30.
-///
-/// # Known blind spot
-///
-/// A CMap that maps letters onto *letters* only produces intact-looking runs
-/// and scores like real text. Broken CMaps reinterpret glyph IDs through a
-/// standard encoding, which lands mostly in the digit and punctuation range, so
-/// this stays theoretical - but only a dictionary catches it.
-///
-/// A dictionary is not used because it needs the document's language, and the
-/// SDK cannot supply it here: measured against the same 265 documents,
-/// `NLLanguageRecognizer` rated the broken layer 0.998 (Turkish) while real
-/// German invoices scored as low as 0.096, `NLEmbedding` scored an English
-/// letter and the mojibake identically (0.000) and covers few languages, and
-/// `NSSpellChecker` separated worse than this heuristic (0.31 vs 0.50) at
-/// 71 ms per document.
+/// A letter-onto-letter CMap would slip through, and only a dictionary catches
+/// that - but none is usable here: measured on the same documents,
+/// `NLLanguageRecognizer` rated the broken layer 0.998 (Turkish) against 0.096
+/// for real invoices, `NLEmbedding` scores English text and mojibake alike, and
+/// `NSSpellChecker` separates worse at 71 ms per document.
 public enum TextReadability {
 
-    /// Letters in an uninterrupted run of at least this length are counted as
-    /// belonging to a word.
+    /// Letters in a run of at least this length count as part of a word.
     static let minimumRunLength = 4
 
     /// Minimum share of letters that must sit in word-like runs.
     static let minimumWordLetterShare = 0.5
 
-    /// Below this many letters the sample is too small to judge - a short
-    /// header is not enough evidence to declare a document unreadable.
+    /// Below this many letters there is not enough evidence to judge.
     static let minimumLetterCount = 50
 
     /// Returns `true` if `text` plausibly contains real words.
     ///
-    /// Errs on the side of `true`: both call sites act destructively on a
-    /// `false` (re-rasterizing a page, dropping AI suggestions), so only a
-    /// clear verdict should trigger them.
+    /// Errs towards `true`: a `false` re-rasterizes a page or drops AI
+    /// suggestions, so only a clear verdict should trigger it.
     public static func isReadable(_ text: String) -> Bool {
         var totalLetters = 0
         var wordLetters = 0

--- a/ArchiverLib/Sources/ArchiverModels/TextReadability.swift
+++ b/ArchiverLib/Sources/ArchiverModels/TextReadability.swift
@@ -23,6 +23,21 @@ import Foundation
 /// archive documents the share never dropped below 0.73 - not for number-heavy
 /// invoices and payslips, and not where PDFKit swallowed every space - while
 /// the broken layer above scores 0.30.
+///
+/// # Known blind spot
+///
+/// A CMap that maps letters onto *letters* only produces intact-looking runs
+/// and scores like real text. Broken CMaps reinterpret glyph IDs through a
+/// standard encoding, which lands mostly in the digit and punctuation range, so
+/// this stays theoretical - but only a dictionary catches it.
+///
+/// A dictionary is not used because it needs the document's language, and the
+/// SDK cannot supply it here: measured against the same 265 documents,
+/// `NLLanguageRecognizer` rated the broken layer 0.998 (Turkish) while real
+/// German invoices scored as low as 0.096, `NLEmbedding` scored an English
+/// letter and the mojibake identically (0.000) and covers few languages, and
+/// `NSSpellChecker` separated worse than this heuristic (0.31 vs 0.50) at
+/// 71 ms per document.
 public enum TextReadability {
 
     /// Letters in an uninterrupted run of at least this length are counted as

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractionPromptFactory.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractionPromptFactory.swift
@@ -84,6 +84,7 @@ enum ContentExtractionPromptFactory {
     static let taskInstruction = """
     Your task is to archive documents by analyzing their content and generating appropriate descriptions and tags.
     If the document content does not contain enough information to create good tags/description, you MUST NOT hallucinate them - just return empty values.
+    NEVER describe the document text itself or its quality (e.g. "unreadable document text", "garbled text", "no content") - return empty values instead.
     """
 
     static func tagsInstruction(stats: DocumentStats, locale: Locale) -> String {

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
@@ -73,9 +73,8 @@ public actor ContentExtractorStore {
     public func extract(from text: String, customPrompt: String? = nil, with documents: [Document], documentId: Document.ID? = nil) async throws -> Info? {
         guard availability().isUsable else { return nil }
 
-        // Asked to summarize mojibake, the model describes the mojibake ("Unlesbarer
-        // Dokumententext") instead of returning empty values. Checked before the
-        // cache read so entries created before this guard existed are dropped too.
+        // Asked to summarize mojibake, the model describes it ("Unlesbarer
+        // Dokumententext"). Before the cache read, so stale entries go too.
         guard TextReadability.isReadable(text) else {
             Logger.contentExtractor.info("Skipping extraction, document text is not readable")
             return nil

--- a/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
+++ b/ArchiverLib/Sources/ContentExtractorStore/ContentExtractorStore.swift
@@ -68,9 +68,18 @@ public actor ContentExtractorStore {
     ///   - customPrompt: Optional custom prompt to guide the extraction
     ///   - documents: Existing documents for context (tags, specifications)
     ///   - documentId: Optional document ID for caching results
-    /// - Returns: Extracted specification and tags, or nil if unavailable
+    /// - Returns: Extracted specification and tags, or nil if unavailable or if
+    ///   the document text is not readable
     public func extract(from text: String, customPrompt: String? = nil, with documents: [Document], documentId: Document.ID? = nil) async throws -> Info? {
         guard availability().isUsable else { return nil }
+
+        // Asked to summarize mojibake, the model describes the mojibake ("Unlesbarer
+        // Dokumententext") instead of returning empty values. Checked before the
+        // cache read so entries created before this guard existed are dropped too.
+        guard TextReadability.isReadable(text) else {
+            Logger.contentExtractor.info("Skipping extraction, document text is not readable")
+            return nil
+        }
 
         // Check cache if document ID is provided
         if let documentId,

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/PDFMetadata.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/PDFMetadata.swift
@@ -27,10 +27,9 @@ public enum PDFMetadata {
     /// Returns `true` if the PDF has *usable* extractable text on any of its
     /// first pages.
     ///
-    /// A text layer whose `ToUnicode` CMap does not match the embedded font
-    /// subset extracts as mojibake (see ``TextReadability``). It is worthless
-    /// for search and for the AI suggestions, so it does not count as a text
-    /// layer and the document gets OCR'd again.
+    /// A layer that extracts as mojibake (see ``TextReadability``) is worthless
+    /// for search and AI suggestions, so it does not count and the document
+    /// gets OCR'd again.
     ///
     /// - Parameters:
     ///   - pdf: The PDF to inspect.

--- a/ArchiverLib/Sources/DocumentProcessingPipeline/PDFMetadata.swift
+++ b/ArchiverLib/Sources/DocumentProcessingPipeline/PDFMetadata.swift
@@ -5,6 +5,7 @@
 //  Created by Julian Kahnert on 07.07.26.
 //
 
+import ArchiverModels
 import Foundation
 import PDFKit
 
@@ -23,7 +24,13 @@ import PDFKit
 /// which makes it unusable as a persistent flag.
 public enum PDFMetadata {
 
-    /// Returns `true` if the PDF has extractable text on any of its first pages.
+    /// Returns `true` if the PDF has *usable* extractable text on any of its
+    /// first pages.
+    ///
+    /// A text layer whose `ToUnicode` CMap does not match the embedded font
+    /// subset extracts as mojibake (see ``TextReadability``). It is worthless
+    /// for search and for the AI suggestions, so it does not count as a text
+    /// layer and the document gets OCR'd again.
     ///
     /// - Parameters:
     ///   - pdf: The PDF to inspect.
@@ -35,7 +42,7 @@ public enum PDFMetadata {
             guard let page = pdf.page(at: index),
                   let text = page.string,
                   !text.isEmpty else { return false }
-            return true
+            return TextReadability.isReadable(text)
         }
     }
 

--- a/ArchiverLib/Tests/ContentExtractorStoreTests/TextReadabilityTests.swift
+++ b/ArchiverLib/Tests/ContentExtractorStoreTests/TextReadabilityTests.swift
@@ -1,0 +1,58 @@
+//
+//  TextReadabilityTests.swift
+//  ContentExtractorStoreTests
+//
+
+import ArchiverModels
+import Foundation
+import Testing
+
+@Suite("TextReadability")
+struct TextReadabilityTests {
+
+    /// A German document paragraph, run through the substitution alphabet of a
+    /// real broken `ToUnicode` CMap (an OCRmyPDF layer that PDFKit extracted as
+    /// mojibake). Same shape as the original: letters scattered between digits
+    /// and symbols, no word survives intact.
+    private let mojibake = """
+    Aaz6§naaz6,a§U3mar§HrK§9a66arff§3r1ai§a6z3t,ar§Aia§Kia§Fa7zrHrn§sHa6§Kia§$iasa6Hrn§dbm§ta,Z,ar\
+    §pbr3,fl§4i,,a§Ha1a6laigar§Aia§Kar§4a,63n§irra6z3t1§dbr§dia6Zazr§W3nar§3Hs§K3g§Hr,ar§nar3rr,a\
+    §übr,bfl§Piatar§U3r.§sHa6§_z6§Pa6,63Har§HrK§_z6a§4ag,attHrn§1ai§Hrga6am§Lr,a6razmarfl
+    """
+
+    private let germanText = """
+    Sehr geehrte Damen und Herren, anbei erhalten Sie die Rechnung für die Lieferung vom letzten \
+    Monat. Bitte überweisen Sie den Betrag innerhalb von vierzehn Tagen auf das unten genannte Konto.
+    """
+
+    @Test("Real document text is readable")
+    func realTextIsReadable() {
+        #expect(TextReadability.isReadable(germanText))
+    }
+
+    @Test("A broken text layer is not readable")
+    func mojibakeIsNotReadable() {
+        #expect(!TextReadability.isReadable(mojibake))
+    }
+
+    @Test("Text without spaces stays readable")
+    func textWithoutSpacesIsReadable() {
+        // PDFKit swallows the spaces of some documents - the words are still
+        // intact, so this must not be mistaken for a broken text layer.
+        #expect(TextReadability.isReadable(germanText.replacing(" ", with: "")))
+    }
+
+    @Test("Number-heavy text stays readable")
+    func numberHeavyTextIsReadable() {
+        let invoice = """
+        Rechnung Nr. 2024-00815 vom 03.05.2024, Kundennummer 571350344, Betrag 1.234,56 EUR,
+        Zahlungsziel 14 Tage, IBAN DE02120300000000202051, Steuersatz 19 Prozent auf alle Posten.
+        """
+        #expect(TextReadability.isReadable(invoice))
+    }
+
+    @Test("Too little text is never judged unreadable", arguments: ["", "Rechnung 2024", "AB1 CD2 EF3"])
+    func shortTextIsReadable(text: String) {
+        #expect(TextReadability.isReadable(text))
+    }
+}

--- a/ArchiverLib/Tests/DocumentProcessingPipelineTests/PDFMetadataTests.swift
+++ b/ArchiverLib/Tests/DocumentProcessingPipelineTests/PDFMetadataTests.swift
@@ -3,6 +3,7 @@
 //  ArchiverLib
 //
 
+import ArchiverModels
 import Foundation
 import PDFKit
 import Testing
@@ -58,6 +59,35 @@ struct PDFMetadataTests {
     func hasTextLayerRespectsMaxPages() throws {
         let pdf = try #require(PDFDocument(url: Bundle.longTextPDFUrl))
         #expect(PDFMetadata.hasTextLayer(pdf, maxPages: 1))
+    }
+
+    @Test
+    func hasTextLayerReturnsFalseForBrokenTextLayer() throws {
+        // A German paragraph run through the substitution alphabet of a real
+        // broken `ToUnicode` CMap: the page carries plenty of text, but no
+        // search and no language model can use it.
+        let mojibake = """
+        Aaz6§naaz6,a§U3mar§HrK§9a66arff§3r1ai§a6z3t,ar§Aia§Kia§Fa7zrHrn§sHa6§Kia§$iasa6Hrn§dbm§ta,Z,ar\
+        §pbr3,fl§4i,,a§Ha1a6laigar§Aia§Kar§4a,63n§irra6z3t1§dbr§dia6Zazr§W3nar§3Hs§K3g§Hr,ar§nar3rr,a\
+        §übr,bfl§Piatar§U3r.§sHa6§_z6§Pa6,63Har§HrK§_z6a§4ag,attHrn§1ai§Hrga6am§Lr,a6razmarfl
+        """
+        let pdf = Self.createTextPDF(mojibake)
+
+        try #require(pdf.page(at: 0)?.string?.isEmpty == false, "the fixture must actually carry text")
+        #expect(!PDFMetadata.hasTextLayer(pdf))
+    }
+
+    /// The readability check must not reject the app's own OCR output — that
+    /// would re-OCR every scanned document on every pass.
+    @Test(.tags(.ocr))
+    func hasTextLayerReturnsTrueAfterOwnOCR() async throws {
+        let image = try #require(PlatformImage(contentsOf: Bundle.billPNGUrl))
+        let pdf = Self.createImageOnlyPDF(from: image)
+        try #require(!PDFMetadata.hasTextLayer(pdf))
+
+        try await PDFOCREngine.addTextLayer(to: pdf, quality: .lossless)
+
+        #expect(PDFMetadata.hasTextLayer(pdf))
     }
 
     // MARK: - isMarked
@@ -132,6 +162,37 @@ struct PDFMetadataTests {
     }
 
     // MARK: - Helpers
+
+    /// Create a single-page PDF containing only `text` for testing.
+    static func createTextPDF(_ text: String) -> PDFDocument {
+        let bounds = CGRect(x: 0, y: 0, width: 595, height: 842)
+        let data = NSMutableData()
+        var mediaBox = bounds
+        // swiftlint:disable force_unwrapping
+        let consumer = CGDataConsumer(data: data)!
+        let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil)!
+        // swiftlint:enable force_unwrapping
+
+        context.beginPDFPage(nil)
+        #if canImport(UIKit)
+        UIGraphicsPushContext(context)
+        defer { UIGraphicsPopContext() }
+        let font = UIFont.systemFont(ofSize: 11)
+        #else
+        let previousContext = NSGraphicsContext.current
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: true)
+        defer { NSGraphicsContext.current = previousContext }
+        let font = NSFont.systemFont(ofSize: 11)
+        #endif
+
+        context.concatenate(CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: bounds.height))
+        NSAttributedString(string: text, attributes: [.font: font]).draw(in: bounds.insetBy(dx: 40, dy: 40))
+        context.endPDFPage()
+        context.closePDF()
+
+        // swiftlint:disable:next force_unwrapping
+        return PDFDocument(data: data as Data)!
+    }
 
     /// Create a PDF containing only an image (no text layer) for testing.
     static func createImageOnlyPDF(from image: PlatformImage) -> PDFDocument {

--- a/ArchiverLib/Tests/DocumentProcessingPipelineTests/PDFMetadataTests.swift
+++ b/ArchiverLib/Tests/DocumentProcessingPipelineTests/PDFMetadataTests.swift
@@ -64,8 +64,7 @@ struct PDFMetadataTests {
     @Test
     func hasTextLayerReturnsFalseForBrokenTextLayer() throws {
         // A German paragraph run through the substitution alphabet of a real
-        // broken `ToUnicode` CMap: the page carries plenty of text, but no
-        // search and no language model can use it.
+        // broken `ToUnicode` CMap.
         let mojibake = """
         Aaz6§naaz6,a§U3mar§HrK§9a66arff§3r1ai§a6z3t,ar§Aia§Kia§Fa7zrHrn§sHa6§Kia§$iasa6Hrn§dbm§ta,Z,ar\
         §pbr3,fl§4i,,a§Ha1a6laigar§Aia§Kar§4a,63n§irra6z3t1§dbr§dia6Zazr§W3nar§3Hs§K3g§Hr,ar§nar3rr,a\
@@ -77,8 +76,7 @@ struct PDFMetadataTests {
         #expect(!PDFMetadata.hasTextLayer(pdf))
     }
 
-    /// The readability check must not reject the app's own OCR output — that
-    /// would re-OCR every scanned document on every pass.
+    /// Rejecting the app's own OCR output would re-OCR every scan on every pass.
     @Test(.tags(.ocr))
     func hasTextLayerReturnsTrueAfterOwnOCR() async throws {
         let image = try #require(PlatformImage(contentsOf: Bundle.billPNGUrl))


### PR DESCRIPTION
Ein PDF, dessen `ToUnicode`-CMap nicht zum Font-Subset passt (hier ein OCRmyPDF-Layer), extrahiert als Mojibake: `Mandatsreferenz (wird von` → `I9Aü9O-P$p$P$Ax31J(Pü3VWA3`.

`hasTextLayer` prüfte nur auf nicht-leeren Text, also übersprang der OCR-Lauf das Dokument. Der Mojibake ging danach ans Sprachmodell, das ihn beschrieb statt leere Werte zu liefern — daher die Beschreibung "Unlesbarer Dokumententext".

Zu entscheiden:
- **Schwelle 0.5** in `TextReadability`: über 265 echten Archivdokumenten min. 0.73, kaputter Layer 0.30. Ein Fehlalarm rastert eine Seite mit 3x (~216 dpi) neu — irreversibel, daher konservativ.
- **Kein Wörterbuch-Check**: `NLLanguageRecognizer` hält den Mojibake mit 0.998 für Türkisch und echte Rechnungen für 0.096, `NLEmbedding` bewertet englischen Text und Mojibake gleich (0.000), `NSSpellChecker` trennt schlechter bei 71 ms/Dokument. Bekannte Lücke ist damit eine Buchstaben-auf-Buchstaben-CMap; im Doc-Kommentar festgehalten.

Nicht verifiziert: nur ein echtes Mojibake-Sample. End-to-End auf dem gemeldeten Dokument geprüft (kein Textlayer → OCR → lesbarer Text), 223 Tests grün, iOS-Build ok.