### PR TITLE
Skip tag selection delay when no suggestions remain

### DIFF
--- a/ArchiverLib/Sources/ArchiverFeatures/DocumentInformationForm/DocumentInformationForm.swift
+++ b/ArchiverLib/Sources/ArchiverFeatures/DocumentInformationForm/DocumentInformationForm.swift
@@ -172,28 +172,34 @@ struct DocumentInformationForm {
                 // remove current tagSearchteam
                 state.tagSearchterm = ""
 
-                // If multi-tag selection delay is enabled, start the timer
-                if state.multiTagSelectionDelayEnabled {
-                    state.isTagSelectionDelayActive = true
+                // The delay only buys time to pick more of the shown suggestions - with none left there is nothing to wait for
+                guard state.multiTagSelectionDelayEnabled,
+                      !state.suggestedTags.isEmpty else {
+                    state.isTagSelectionDelayActive = false
                     state.tagSelectionDelayProgress = 0.0
 
-                    return .run { send in
-                        let delayDuration: TimeInterval = 2
-                        let steps = 20
-                        let stepDuration = delayDuration / Double(steps)
-
-                        for step in 1...steps {
-                            try await clock.sleep(for: .seconds(stepDuration))
-                            await send(.updateTagSelectionDelayProgress(Double(step) / Double(steps)))
-                        }
-
-                        await send(.tagSelectionDelayCompleted)
-                    }
-                    .cancellable(id: CancelID.tagSelectionDelayTimer, cancelInFlight: true)
-                } else {
-                    // If delay is disabled, update suggestions immediately
-                    return .send(.startUpdatingTagSuggestions)
+                    return .concatenate(
+                        .cancel(id: CancelID.tagSelectionDelayTimer),
+                        .send(.startUpdatingTagSuggestions)
+                    )
                 }
+
+                state.isTagSelectionDelayActive = true
+                state.tagSelectionDelayProgress = 0.0
+
+                return .run { send in
+                    let delayDuration: TimeInterval = 2
+                    let steps = 20
+                    let stepDuration = delayDuration / Double(steps)
+
+                    for step in 1...steps {
+                        try await clock.sleep(for: .seconds(stepDuration))
+                        await send(.updateTagSelectionDelayProgress(Double(step) / Double(steps)))
+                    }
+
+                    await send(.tagSelectionDelayCompleted)
+                }
+                .cancellable(id: CancelID.tagSelectionDelayTimer, cancelInFlight: true)
 
             case .onTask:
                 state.isLoading = true

--- a/ArchiverLib/Tests/ArchiverFeaturesTests/DocumentDetailsTests.swift
+++ b/ArchiverLib/Tests/ArchiverFeaturesTests/DocumentDetailsTests.swift
@@ -34,7 +34,12 @@ struct DocumentDetailsTests {
             $0.documentInformationForm.document.specification = "new specification"
         }
 
+        await store.send(.showDocumentInformationForm(.updateTagSuggestions(["keep", "tag1"]))) {
+            $0.documentInformationForm.suggestedTags = ["keep", "tag1"]
+        }
+
         await store.send(.showDocumentInformationForm(.onTagSuggestionTapped("tag1"))) {
+            $0.documentInformationForm.suggestedTags = ["keep"]
             $0.documentInformationForm.document.tags = ["tag1"]
             $0.documentInformationForm.isTagSelectionDelayActive = true
             $0.documentInformationForm.tagSelectionDelayProgress = 0.0
@@ -56,7 +61,9 @@ struct DocumentDetailsTests {
         }
 
         await store.receive(.showDocumentInformationForm(.startUpdatingTagSuggestions))
-        await store.receive(.showDocumentInformationForm(.updateTagSuggestions([])))
+        await store.receive(.showDocumentInformationForm(.updateTagSuggestions([]))) {
+            $0.documentInformationForm.suggestedTags = []
+        }
 
         // close inspector without saving
         await store.send(.onEditButtonTapped) {

--- a/ArchiverLib/Tests/ArchiverFeaturesTests/DocumentInformationFormTests.swift
+++ b/ArchiverLib/Tests/ArchiverFeaturesTests/DocumentInformationFormTests.swift
@@ -115,33 +115,15 @@ struct DocumentInformationFormTests {
 
     @Test
     func addingTagUpdatesDocument() async throws {
-        let clock = TestClock()
-        let store = TestStore(initialState: DocumentInformationForm.State(document: .mock())) {
+        let store = TestStore(initialState: DocumentInformationForm.State(document: .mock(), suggestedTags: ["invoice"])) {
             DocumentInformationForm()
         } withDependencies: {
             $0.archiveStore.getTagSuggestionsSimilarTo = { _ in [] }
-            $0.continuousClock = clock
         }
 
         await store.send(.onTagSuggestionTapped("invoice")) {
+            $0.suggestedTags = []
             $0.document.tags = ["invoice"]
-            $0.isTagSelectionDelayActive = true
-            $0.tagSelectionDelayProgress = 0.0
-        }
-
-        // Advance clock through the 2-second delay timer
-        await clock.advance(by: .seconds(2))
-
-        // Receive all progress updates
-        for step in 1...20 {
-            await store.receive(.updateTagSelectionDelayProgress(Double(step) / 20.0)) {
-                $0.tagSelectionDelayProgress = Double(step) / 20.0
-            }
-        }
-
-        await store.receive(.tagSelectionDelayCompleted) {
-            $0.isTagSelectionDelayActive = false
-            $0.tagSelectionDelayProgress = 0.0
         }
 
         await store.receive(.startUpdatingTagSuggestions)
@@ -388,7 +370,7 @@ struct DocumentInformationFormTests {
     @Test
     func multiTagSelectionDelayProgressUpdates() async throws {
         let clock = TestClock()
-        let store = TestStore(initialState: DocumentInformationForm.State(document: .mock())) {
+        let store = TestStore(initialState: DocumentInformationForm.State(document: .mock(), suggestedTags: ["keep", "tag1"])) {
             DocumentInformationForm()
         } withDependencies: {
             $0.archiveStore.getTagSuggestionsSimilarTo = { _ in [] }
@@ -397,6 +379,7 @@ struct DocumentInformationFormTests {
 
         // Select first tag
         await store.send(.onTagSuggestionTapped("tag1")) {
+            $0.suggestedTags = ["keep"]
             $0.document.tags = ["tag1"]
             $0.isTagSelectionDelayActive = true
             $0.tagSelectionDelayProgress = 0.0
@@ -429,13 +412,15 @@ struct DocumentInformationFormTests {
         }
 
         await store.receive(.startUpdatingTagSuggestions)
-        await store.receive(.updateTagSuggestions([]))
+        await store.receive(.updateTagSuggestions([])) {
+            $0.suggestedTags = []
+        }
     }
 
     @Test
     func multiTagSelectionDelayCanBeCancelled() async throws {
         let clock = TestClock()
-        let store = TestStore(initialState: DocumentInformationForm.State(document: .mock())) {
+        let store = TestStore(initialState: DocumentInformationForm.State(document: .mock(), suggestedTags: ["keep", "tag1", "tag2"])) {
             DocumentInformationForm()
         } withDependencies: {
             $0.archiveStore.getTagSuggestionsSimilarTo = { _ in [] }
@@ -444,6 +429,7 @@ struct DocumentInformationFormTests {
 
         // Select first tag
         await store.send(.onTagSuggestionTapped("tag1")) {
+            $0.suggestedTags = ["keep", "tag2"]
             $0.document.tags = ["tag1"]
             $0.isTagSelectionDelayActive = true
             $0.tagSelectionDelayProgress = 0.0
@@ -461,6 +447,7 @@ struct DocumentInformationFormTests {
 
         // Select another tag, which should cancel the previous timer
         await store.send(.onTagSuggestionTapped("tag2")) {
+            $0.suggestedTags = ["keep"]
             $0.document.tags = ["tag1", "tag2"]
             $0.isTagSelectionDelayActive = true
             $0.tagSelectionDelayProgress = 0.0
@@ -482,6 +469,63 @@ struct DocumentInformationFormTests {
         }
 
         await store.receive(.startUpdatingTagSuggestions)
+        await store.receive(.updateTagSuggestions([])) {
+            $0.suggestedTags = []
+        }
+    }
+
+    @Test
+    func lastSuggestedTagSkipsSelectionDelay() async throws {
+        let clock = TestClock()
+        let store = TestStore(initialState: DocumentInformationForm.State(document: .mock(), suggestedTags: ["tag1"])) {
+            DocumentInformationForm()
+        } withDependencies: {
+            $0.archiveStore.getTagSuggestionsSimilarTo = { _ in [] }
+            $0.continuousClock = clock
+        }
+
+        await store.send(.onTagSuggestionTapped("tag1")) {
+            $0.suggestedTags = []
+            $0.document.tags = ["tag1"]
+        }
+
+        await store.receive(.startUpdatingTagSuggestions)
         await store.receive(.updateTagSuggestions([]))
+    }
+
+    @Test
+    func lastSuggestedTagCancelsRunningSelectionDelay() async throws {
+        let clock = TestClock()
+        let store = TestStore(initialState: DocumentInformationForm.State(document: .mock(), suggestedTags: ["tag1", "tag2"])) {
+            DocumentInformationForm()
+        } withDependencies: {
+            $0.archiveStore.getTagSuggestionsSimilarTo = { _ in [] }
+            $0.continuousClock = clock
+        }
+
+        await store.send(.onTagSuggestionTapped("tag1")) {
+            $0.suggestedTags = ["tag2"]
+            $0.document.tags = ["tag1"]
+            $0.isTagSelectionDelayActive = true
+            $0.tagSelectionDelayProgress = 0.0
+        }
+
+        await clock.advance(by: .seconds(0.1))
+        await store.receive(.updateTagSelectionDelayProgress(0.05)) {
+            $0.tagSelectionDelayProgress = 0.05
+        }
+
+        await store.send(.onTagSuggestionTapped("tag2")) {
+            $0.suggestedTags = []
+            $0.document.tags = ["tag1", "tag2"]
+            $0.isTagSelectionDelayActive = false
+            $0.tagSelectionDelayProgress = 0.0
+        }
+
+        await store.receive(.startUpdatingTagSuggestions)
+        await store.receive(.updateTagSuggestions([]))
+
+        // the timer of the first tag must be gone - otherwise its progress updates arrive here
+        await clock.advance(by: .seconds(2))
     }
 }


### PR DESCRIPTION
## Changes

- Tapping the last visible tag suggestion refreshes suggestions immediately, regardless of the multi-tag selection delay setting
- A running delay timer is cancelled in that case, so no stale progress updates arrive
- `addingTagUpdatesDocument` now covers the immediate path; the delay tests keep a suggestion visible