### PR TITLE
Stop swiftlint --fix from breaking the share extension

### DIFF
--- a/ShareExtension/NSItemProvider.swift
+++ b/ShareExtension/NSItemProvider.swift
@@ -24,15 +24,15 @@ extension NSItemProvider {
     }
 
     func saveData(at url: URL, with validUTIs: [UTType]) async throws -> Bool {
-        var error: (any Error)?
+        var lastError: (any Error)?
         var data: Data?
         var sourceURL: URL?
 
         for uti in validUTIs where hasItemConformingToTypeIdentifier(uti.identifier) {
             do {
                 (data, sourceURL) = try await getItem(for: uti)
-            } catch let inputError {
-                error = inputError
+            } catch {
+                lastError = error
             }
 
             guard let data else { continue }
@@ -57,8 +57,8 @@ extension NSItemProvider {
             }
         }
 
-        if let err = error {
-            throw err
+        if let lastError {
+            throw lastError
         }
 
         return false


### PR DESCRIPTION
- `ShareExtension/NSItemProvider.swift`: the outer `var error` is now `lastError`, and the `catch` uses Swift's implicit `error` binding
- `untyped_error_in_catch` is satisfied without a named binding, so `swiftlint --fix` no longer rewrites the file into a non-compiling state (previously fixed by hand in 98da74f9)
- The rename covers the `throw` at the end of `saveData(at:with:)`, which reads the same variable

The outer variable had to be the one renamed: with both named `error`, the catch's implicit binding shadows the outer one and `error = error` compiles as a silent self-assignment that swallows the failure.

Verified: `swiftlint lint --strict` clean (0 violations, was 1); `swiftlint --fix` leaves the file byte-identical, while the same run on `develop` still rewrites it; iOS scheme builds including the share extension.